### PR TITLE
Fix the folder "vmcs_host/linux"

### DIFF
--- a/configure
+++ b/configure
@@ -426,7 +426,7 @@ fi
 
 # check for VideoCore stuff for Raspberry Pi
 if [ -d /opt/vc/include -a -d /opt/vc/lib ]; then
-  CFLAGS_GLES="$CFLAGS_GLES -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads"
+  CFLAGS_GLES="$CFLAGS_GLES -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux"
   LDLIBS_GLES="$LDLIBS_GLES -L/opt/vc/lib"
   need_xlib="yes"
 fi


### PR DESCRIPTION
A time ago, the Raspberry Pi OS developers change the path of some headers, they move the folder  from /opt/vc/include/interface/vcos/pthreads  to /opt/vc/include/interface/vmcs_host/linux, without this change the users need to put this line by hand in the generated makefile.
