### PR TITLE
Use ARMv6 instructions if HAVE_ARMV6 is present.

### DIFF
--- a/include/arm_features.h
+++ b/include/arm_features.h
@@ -3,7 +3,7 @@
 
 #if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
  || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
- || defined(__ARM_ARCH_7EM__)
+ || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_7S__)
 
 #define HAVE_ARMV7
 #define HAVE_ARMV6

--- a/libpcsxcore/gte_arm.S
+++ b/libpcsxcore/gte_arm.S
@@ -11,7 +11,7 @@
 .align 2
 
 .macro sgnxt16 rd rs
-#ifdef HAVE_ARMV7
+#ifdef HAVE_ARMV6
     sxth     \rd, \rs
 #else
     lsl      \rd, \rs, #16
@@ -28,7 +28,7 @@
 .endm
 
 .macro ssatx rd wr bit
-#ifdef HAVE_ARMV7
+#ifdef HAVE_ARMV6
     ssat     \rd, #\bit, \rd
 #else
     cmp      \rd, \wr
@@ -52,7 +52,7 @@
 .endm
 
 .macro usat16_ rd rs
-#ifdef HAVE_ARMV7
+#ifdef HAVE_ARMV6
     usat     \rd, #16, \rs
 #else
     subs     \rd, \rs, #0

--- a/libpcsxcore/new_dynarec/assem_arm.c
+++ b/libpcsxcore/new_dynarec/assem_arm.c
@@ -1285,7 +1285,7 @@ void emit_andimm(int rs,int imm,int rt)
     assem_debug("bic %s,%s,#%d\n",regname[rt],regname[rs],imm);
     output_w32(0xe3c00000|rd_rn_rm(rt,rs,0)|armval);
   }else if(imm==65535) {
-    #ifndef HAVE_ARMV7
+    #ifndef HAVE_ARMV6
     assem_debug("bic %s,%s,#FF000000\n",regname[rt],regname[rs]);
     output_w32(0xe3c00000|rd_rn_rm(rt,rs,0)|0x4FF);
     assem_debug("bic %s,%s,#00FF0000\n",regname[rt],regname[rt]);
@@ -1418,7 +1418,7 @@ void emit_shrdimm(int rs,int rs2,u_int imm,int rt)
 
 void emit_signextend16(int rs,int rt)
 {
-  #ifndef HAVE_ARMV7
+  #ifndef HAVE_ARMV6
   emit_shlimm(rs,16,rt);
   emit_sarimm(rt,16,rt);
   #else
@@ -1429,7 +1429,7 @@ void emit_signextend16(int rs,int rt)
 
 void emit_signextend8(int rs,int rt)
 {
-  #ifndef HAVE_ARMV7
+  #ifndef HAVE_ARMV6
   emit_shlimm(rs,24,rt);
   emit_sarimm(rt,24,rt);
   #else

--- a/libpcsxcore/new_dynarec/assem_arm.h
+++ b/libpcsxcore/new_dynarec/assem_arm.h
@@ -5,7 +5,9 @@
 
 #define HOST_IMM8 1
 #define HAVE_CMOV_IMM 1
+#ifdef HAVE_ARMV7
 #define CORTEX_A8_BRANCH_PREDICTION_HACK 1
+#endif
 #define USE_MINI_HT 1
 //#define REG_PREFETCH 1
 #define HAVE_CONDITIONAL_CALL 1


### PR DESCRIPTION
There are some ARMv6 instructions which are only used if HAVE_ARMV7 is defined. I modified get_arm.S and assem_arm.c so we can use these instructions if HAVE_ARMV6 is defined. I also disabled CORTEX_A8_BRANCH_PREDICTION_HACK for architectures <ARMV7 and added __ARM_ARCH_7S_ (Apple A6).

The modifications were tested with a libreto branch:
https://github.com/gizmo98/pcsx_rearmed/commits/rpi