### PR TITLE
psxmem: Reads of PIO Expansion area read all-ones.

### DIFF
--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -187,7 +187,7 @@ void psxMemReset() {
 	char bios[1024];
 
 	memset(psxM, 0, 0x00200000);
-	memset(psxP, 0, 0x00010000);
+	memset(psxP, 0xff, 0x00010000);
 
 	if (strcmp(Config.Bios, "HLE") != 0) {
 		sprintf(bios, "%s/%s", Config.BiosDir, Config.Bios);


### PR DESCRIPTION
Credits to @senquack for fixing the issue, i was just the one, well, pointing the issue as to why the game would crash hehehe. This is what he says about it :
> Fixes 'Tetris with Card Captor Sakura - Eternal Heart (Japan)' startup.
Thanks to gameblabla for finding this issue and pointing out that
Mednafen had a fix for it. It's adapted here in a much simpler form.

Patch basically sets all the bits on reads in the PIO memory area. With the fix in place, Tetris With Card Captor Sakura is now playable.