### PR TITLE
gpulib: fix out-of-bounds reads in do_cmd_buffer()

### DIFF
--- a/plugins/gpulib/gpu.c
+++ b/plugins/gpulib/gpu.c
@@ -457,6 +457,12 @@ static noinline int do_cmd_buffer(uint32_t *data, int count)
 
     cmd = data[pos] >> 24;
     if (0xa0 <= cmd && cmd <= 0xdf) {
+      if (unlikely((pos+2) >= count)) {
+        // incomplete vram write/read cmd, can't consume yet
+        cmd = -1;
+        break;
+      }
+
       // consume vram write/read cmd
       start_vram_transfer(data[pos + 1], data[pos + 2], (cmd & 0xe0) == 0xc0);
       pos += 3;


### PR DESCRIPTION
Fixes corrupted gfx in this PS1 .exe test utility:
https://github.com/PeterLemon/PSX/tree/master/CPUTest/CPU/LOADSTORE/LW
(This and almost all similar tests on Peter's site).