### PR TITLE
cdrom: add missing BCD->int convert in cdrFreeze()

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -1498,7 +1498,9 @@ int cdrFreeze(void *f, int Mode) {
 		pTransfer = cdr.Transfer + tmp;
 
 		// read right sub data
-		memcpy(tmpp, cdr.Prev, 3);
+		tmpp[0] = btoi(cdr.Prev[0]);
+		tmpp[1] = btoi(cdr.Prev[1]);
+		tmpp[2] = btoi(cdr.Prev[2]);
 		cdr.Prev[0]++;
 		ReadTrack(tmpp);
 


### PR DESCRIPTION
For some Eboot .PBP game images, when loading a savestate, a zlib error
like 'uncompress failed with -5 for block 5383, sector 86132' would be
output to stdout/stderr. The savestate would still be playable, though.

Traced it down to cdrFreeze() failing to convert cdr.Prev from BCD->int
when calling ReadTrack(). Note that the odd 'cdr.Prev[0]++;' line seems
to be someone's hacky way of forcing ReadTrack() to avoid skipping what
it thinks is a duplicate sector read.