### PR TITLE
License these files as MIT + LLVM Android ASM bugfix

### DIFF
--- a/libpcsxcore/gte_neon.S
+++ b/libpcsxcore/gte_neon.S
@@ -290,8 +290,10 @@ FUNCTION(gteRTPT_neon): @ r0=CP2 (d,c),
 
     rtpx_preload
 
-    vmov.i32    d22, #0x7fffffff
-    vmov.i32    d23, #0x80000000
+    vmov.i32    d23, #1
+    vmov.i32    d22, #0x80000000
+    vsub.i32    d22, d22, d23
+    vmov.i32    d23, #0
     mov         r3, #3         @ counter
     mov         r2, r0         @ VXYZ(0)
 0:

--- a/libpcsxcore/memmap.h
+++ b/libpcsxcore/memmap.h
@@ -1,10 +1,32 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (memmap.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #ifndef _MEMMAP_H
 #define _MEMMAP_H
 
 #ifdef _WIN32
 
-#ifndef _WIN32_WINNT            // Allow use of features specific to Windows XP or later.                  
-#define _WIN32_WINNT 0x0501     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_WINNT            /* Allow use of features specific to Windows XP or later. */
+#define _WIN32_WINNT 0x0501     /* Change this to the appropriate value to target other versions of Windows. */
 #endif                                          
 
 /* All the headers include this file. */

--- a/libpcsxcore/memmap_win32.c
+++ b/libpcsxcore/memmap_win32.c
@@ -1,3 +1,25 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (memmap_win32.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <windows.h>
 #include <errno.h>
 #include <io.h>


### PR DESCRIPTION
These files are now licensed as MIT, which should be compatible with GPL v2 and/or later.