### PR TITLE
Add internal database for problematic games

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -DPCNT
 endif
 
 # core
-OBJS += libpcsxcore/cdriso.o libpcsxcore/cdrom.o libpcsxcore/cheat.o libpcsxcore/debug.o \
+OBJS += libpcsxcore/cdriso.o libpcsxcore/cdrom.o libpcsxcore/cheat.o libpcsxcore/database.o libpcsxcore/debug.o \
 	libpcsxcore/decode_xa.o libpcsxcore/disr3000a.o libpcsxcore/mdec.o \
 	libpcsxcore/misc.o libpcsxcore/plugins.o libpcsxcore/ppf.o libpcsxcore/psxbios.o \
 	libpcsxcore/psxcommon.o libpcsxcore/psxcounters.o libpcsxcore/psxdma.o libpcsxcore/psxhle.o \

--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -1,0 +1,36 @@
+#include "misc.h"
+#include "../plugins/dfsound/spu_config.h"
+#include "sio.h"
+
+/* It's duplicated from emu_if.c */
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
+static const char MemorycardHack_db[8][10] =
+{
+	/* Lifeforce Tenka, also known as Codename Tenka */
+	{"SLES00613"},
+	{"SLED00690"},
+	{"SLES00614"},
+	{"SLES00615"},
+	{"SLES00616"},
+	{"SLES00617"},
+	{"SCUS94409"}
+};
+
+/* Function for automatic patching according to GameID. */
+void Apply_Hacks_Cdrom()
+{
+	uint32_t i;
+	
+	/* Apply Memory card hack for Codename Tenka. (The game needs one of the memory card slots to be empty) */
+	for(i=0;i<ARRAY_SIZE(MemorycardHack_db);i++)
+	{
+		if (strncmp(CdromId, MemorycardHack_db[i], 9) == 0)
+		{
+			/* Disable the second memory card slot for the game */
+			Config.Mcd2[0] = 0;
+			/* This also needs to be done because in sio.c, they don't use Config.Mcd2 for that purpose */
+			McdDisable[1] = 1;
+		}
+	}
+}

--- a/libpcsxcore/database.h
+++ b/libpcsxcore/database.h
@@ -1,0 +1,6 @@
+#ifndef DATABASE_H
+#define DATABASE_H
+
+extern void Apply_Hacks_Cdrom();
+
+#endif

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -26,6 +26,7 @@
 #include "mdec.h"
 #include "gpu.h"
 #include "ppf.h"
+#include "database.h"
 #include <zlib.h>
 
 char CdromId[10] = "";
@@ -389,6 +390,8 @@ int CheckCdrom() {
 	SysPrintf(_("CD-ROM Label: %.32s\n"), CdromLabel);
 	SysPrintf(_("CD-ROM ID: %.9s\n"), CdromId);
 	SysPrintf(_("CD-ROM EXE Name: %.255s\n"), exename);
+	
+	Apply_Hacks_Cdrom();
 
 	BuildPPFCache();
 

--- a/libpcsxcore/sio.h
+++ b/libpcsxcore/sio.h
@@ -34,6 +34,7 @@ extern "C" {
 #define MCD_SIZE	(1024 * 8 * 16)
 
 extern char Mcd1Data[MCD_SIZE], Mcd2Data[MCD_SIZE];
+extern char McdDisable[2];
 
 void sioWrite8(unsigned char value);
 void sioWriteStat16(unsigned short value);


### PR DESCRIPTION
This adds an internal database for some problematic games, which for now only includes te memory card hack for Codename tenka. (The game will not work otherwise)

There's also a thin patch for Codename tenka so it works over HLE too.
This was tested on a PC and i could confirm it (finally) fixes Codename tenka.

Note that codename tenka also requires digital controls. I think i'll do a separate patch for those. Maybe...