### PR TITLE
Fixed Linked List DMA end marker.

### DIFF
--- a/libpcsxcore/psxdma.c
+++ b/libpcsxcore/psxdma.c
@@ -122,7 +122,8 @@ static u32 gpuDmaChainSize(u32 addr) {
 		// next 32-bit pointer
 		addr = psxMu32( addr & ~0x3 ) & 0xffffff;
 		size += 1;
-	} while (addr != 0xffffff);
+	} while (!(addr & 0x800000)); // contrary to some documentation, the end-of-linked-list marker is not actually 0xFF'FFFF
+                                  // any pointer with bit 23 set will do.
 
 	return size;
 }

--- a/plugins/dfxvideo/gpu.c
+++ b/plugins/dfxvideo/gpu.c
@@ -1060,8 +1060,8 @@ long CALLBACK GPUdmaChain(uint32_t * baseAddrL, uint32_t addr)
    if(count>0) GPUwriteDataMem(&baseAddrL[dmaMem>>2],count);
 
    addr = GETLE32(&baseAddrL[addr>>2])&0xffffff;
-  }
- while (addr != 0xffffff);
+   } while (!(addr & 0x800000)); // contrary to some documentation, the end-of-linked-list marker is not actually 0xFF'FFFF
+                                  // any pointer with bit 23 set will do.
 
  GPUIsIdle;
 

--- a/plugins/gpu-gles/gpuPlugin.c
+++ b/plugins/gpu-gles/gpuPlugin.c
@@ -2205,9 +2205,8 @@ do
   if(count>0) GPUwriteDataMem(&baseAddrL[dmaMem>>2],count);
   
   addr = baseAddrL[addr>>2]&0xffffff;
- }
-while (addr != 0xffffff);
-
+  } while (!(addr & 0x800000)); // contrary to some documentation, the end-of-linked-list marker is not actually 0xFF'FFFF
+                                  // any pointer with bit 23 set will do.
 GPUIsIdle;
 
 return 0;


### PR DESCRIPTION
Taken from PCSX Redux project.
https://github.com/grumpycoders/pcsx-redux/pull/396/commits/a6401da3a4e7b4860b0f7a7f679cf9a93e739caa

According to the original Pull request post :
"LL DMA should end when the pointer of the next node has bit 23 set and not necessarily when it's 0xFF'FFFF"

I think i'm doing it right but i'm not sure what is affected by this.