### PR TITLE
gte: Fix gteH division and sign extension (from PCSX4ALL/senquack)

### DIFF
--- a/libpcsxcore/gte.c
+++ b/libpcsxcore/gte.c
@@ -149,7 +149,13 @@
 #define gteBFC (((s32 *)regs->CP2C.r)[23])
 #define gteOFX (((s32 *)regs->CP2C.r)[24])
 #define gteOFY (((s32 *)regs->CP2C.r)[25])
-#define gteH   (regs->CP2C.p[26].sw.l)
+// senquack - gteH register is u16, not s16, and used in GTE that way.
+//  HOWEVER when read back by CPU using CFC2, it will be incorrectly
+//  sign-extended by bug in original hardware, according to Nocash docs
+//  GTE section 'Screen Offset and Distance'. The emulator does this
+//  sign extension when it is loaded to GTE by CTC2.
+//#define gteH   (psxRegs.CP2C.p[26].sw.l)
+#define gteH   (psxRegs.CP2C.p[26].w.l)
 #define gteDQA (regs->CP2C.p[27].sw.l)
 #define gteDQB (((s32 *)regs->CP2C.r)[28])
 #define gteZSF3 (regs->CP2C.p[29].sw.l)
@@ -254,7 +260,18 @@ static inline u32 limE_(psxCP2Regs *regs, u32 result) {
 #define A3U(x) (x)
 #endif
 
+
+//senquack - n param should be unsigned (will be 'gteH' reg which is u16)
+#ifdef GTE_USE_NATIVE_DIVIDE
+INLINE u32 DIVIDE(u16 n, u16 d) {
+	if (n < d * 2) {
+		return ((u32)n << 16) / d;
+	}
+	return 0xffffffff;
+}
+#else
 #include "gte_divider.h"
+#endif // GTE_USE_NATIVE_DIVIDE
 
 #ifndef FLAGLESS
 

--- a/libpcsxcore/gte_divider.h
+++ b/libpcsxcore/gte_divider.h
@@ -15,4 +15,4 @@
  *  along with this program; if not, see <http://www.gnu.org/licenses>.
  */
 
-u32 DIVIDE(s16 n, u16 d);
+u32 DIVIDE(u16 n, u16 d);


### PR DESCRIPTION
This came from https://github.com/jdgleaver/RG350_pcsx4all/commit/864de6772c35bbf4812d3a9a2d525b2da57d974d

Original comment by senquack :
"gteH register is u16, not s16. DIVIDE macro/func assumed it was
s16 for some reason. Behavior now matches Mednafen."

I'm surprised this wasn't merged back yet and it seems correct.
I also put in there the "GTE_USE_NATIVE_DIVIDE" stuff but currently unless manually enabled, it's not used.
