### PR TITLE
mdec.cpp: Dare to set MDEC_BIAS to 10

### DIFF
--- a/libpcsxcore/mdec.c
+++ b/libpcsxcore/mdec.c
@@ -32,7 +32,14 @@
  * 320x240x16@60Hz => 9.216 MB/s
  * so 2.0 to 4.0 should be fine.
  */
-#define MDEC_BIAS 2
+ 
+/* Was set to 2 before but it would cause issues in R-types and Vandal Hearts videos. 
+ * Setting it to 6 as dmitrysmagin did fix those... except for Galerians.
+ * Galerians needs this to be set to 10 (!!) before it looks properly.
+ * I've tried this with a few other games (including R-Types) and so far, this
+ * has not backfired.
+ * */
+#define MDEC_BIAS 10
 
 #define DSIZE			8
 #define DSIZE2			(DSIZE * DSIZE)


### PR DESCRIPTION
This based on an original fix by dmitrysmagin in PCSX4ALL.
He had this to say :
"This fixes graphic artifacts during cinematics in Vandal Hearts
and R-Types, other games seem to be unaffected. (?)
Need to test more, revert if problems."

I can confirm for me this fixes the graphical issues that happened during the videos in R-types.
People that used the PCSX4ALL fork that used this fix for a while did not seem to have encountered any regressions.
Setting it to 4 still doesn't fix the problem, it needs to be 6.

**Below : MDEC_BIAS set to 2**
![2021-08-16-035248_1920x1080_scrot](https://user-images.githubusercontent.com/8717966/129501345-c38940cb-4cf6-43c7-a4fc-4fdbc6601081.png)

**Below : MDEC_BIAS set to 6**
![2021-08-16-035313_1920x1080_scrot](https://user-images.githubusercontent.com/8717966/129501376-f3c7aed2-f815-4680-92fb-b7648a8ecd1b.png)

However, it turns out MDEC_BIAS set to 6 was still not enough for Galerians.
As said in https://github.com/notaz/pcsx_rearmed/issues/145, Galerians has the same issue but worse.
Setting to 6 makes it look like this
![gal1](https://user-images.githubusercontent.com/8717966/129675034-e6538477-75da-4a3d-9c52-ebf94739e0e2.png)

That game needs MDEC_BIAS to be set to 10 (!!) before it looks properly :
![gal2](https://user-images.githubusercontent.com/8717966/129675042-48020c21-9b0c-46ec-bd04-6c2dcdd55a8e.png)

So far, i have not noticed any regressions from the games i've tried.