### PR TITLE
CHD support from libretro's fork.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "warm"]
 	path = frontend/warm
 	url = git://notaz.gp2x.de/~notaz/warm.git
+[submodule "libchdr"]
+	path = libchdr
+	url = https://github.com/rtissera/libchdr.git

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,16 @@ endif
 
 # cdrcimg
 OBJS += plugins/cdrcimg/cdrcimg.o
+ifeq "$(CHD_SUPPORT)" "1"
+OBJS += libchdr/src/libchdr_bitstream.o
+OBJS += libchdr/src/libchdr_cdrom.o
+OBJS += libchdr/src/libchdr_chd.o
+OBJS += libchdr/src/libchdr_flac.o
+OBJS += libchdr/src/libchdr_huffman.o
+OBJS += libchdr/deps/lzma-19.00/src/Alloc.o libchdr/deps/lzma-19.00/src/Bra86.o libchdr/deps/lzma-19.00/src/BraIA64.o libchdr/deps/lzma-19.00/src/CpuArch.o libchdr/deps/lzma-19.00/src/Delta.o
+OBJS += libchdr/deps/lzma-19.00/src/LzFind.o libchdr/deps/lzma-19.00/src/Lzma86Dec.o libchdr/deps/lzma-19.00/src/LzmaDec.o libchdr/deps/lzma-19.00/src/LzmaEnc.o libchdr/deps/lzma-19.00/src/Sort.o
+CFLAGS += -DHAVE_CHD -D_7ZIP_ST -Ilibchdr/include/libchdr -Ilibchdr/include/dr_libs -Ilibchdr/include -Ilibchdr/deps/lzma-19.00/include
+endif
 
 # dfinput
 OBJS += plugins/dfinput/main.o plugins/dfinput/pad.o plugins/dfinput/guncon.o

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -707,6 +707,9 @@ fail:
 
 static const char *filter_exts[] = {
 	"bin", "img", "mdf", "iso", "cue", "z",
+	#ifdef HAVE_CHD
+	"chd",
+	#endif
 	"bz",  "znx", "pbp", "cbn", NULL
 };
 


### PR DESCRIPTION
This adds CHD support to PCSX Rearmed based on the work of aliaspider for libretro's fork.
The only difference from it is that i'm implementing as a sub-module for maintenance reasons.

It's also not added to the configure script for now as i don't want it to conflict with pull request https://github.com/notaz/pcsx_rearmed/pull/187.
I'll add the option to enable CHD support once that PR is merged...
Or make CHD support mandatory. (but i'm not really willing to do that as on some really low end platforms, CHD support does have a performance/memory impact)