### PR TITLE
[SPU] Emulate SPUSTAT[5:0] as a mirror of SPUCNT[5:0]

### DIFF
--- a/plugins/dfsound/registers.c
+++ b/plugins/dfsound/registers.c
@@ -315,7 +315,7 @@ unsigned short CALLBACK SPUreadRegister(unsigned long reg)
      return spu.spuCtrl;
 
     case H_SPUstat:
-     return spu.spuStat;
+     return (spu.spuStat & ~0x3F) | (spu.spuCtrl & 0x3F);
         
     case H_SPUaddr:
      return (unsigned short)(spu.spuAddr>>3);


### PR DESCRIPTION
Fix is from PCSX-Redux :
https://github.com/grumpycoders/pcsx-redux/commit/4e905d7953a26bffd52f486dc5b03c2a19075d01

I have tested the fix against Loonies 8192 (a PSn00bSDK made homebrew game) and it no longer locks up during loading.
This affects all games and demos that uses PSn00bSDK. (I've been told it's unlikely this will affect games that uses the official SDK)