### PR TITLE
Rewrite GPU bios functions according to OpenBIOS.

### DIFF
--- a/libpcsxcore/psxbios.c
+++ b/libpcsxcore/psxbios.c
@@ -1411,37 +1411,37 @@ void psxBios_FlushCache() { // 44
 
 void psxBios_GPU_dw() { // 0x46
 	int size;
-	s32 *ptr;
+	u32 *ptr;
 
 #ifdef PSXBIOS_LOG
 	PSXBIOS_LOG("psxBios_%s\n", biosA0n[0x46]);
 #endif
 
 	GPU_writeData(0xa0000000);
-	GPU_writeData((a1<<16)|(a0&0xffff));
-	GPU_writeData((a3<<16)|(a2&0xffff));
-	size = (a2*a3+1)/2;
-	ptr = (s32*)PSXM(Rsp[4]);  //that is correct?
-	do {
-		GPU_writeData(SWAP32(*ptr));
-		ptr++;
-	} while(--size);
+	GPU_writeData((a1<<0x10)|(a0&0xffff));
+	GPU_writeData((a3<<0x10)|(a2&0xffff));
+	size = (a2*a3)/2;
+	ptr = (u32*)PSXM(Rsp[4]);  //that is correct?
+	while(size--)
+	{
+		GPU_writeData(SWAPu32(*ptr++));
+	} 
 
 	pc0 = ra;
 }  
 
 void psxBios_mem2vram() { // 0x47
 	int size;
-
+	gpuSyncPluginSR();
 	GPU_writeData(0xa0000000);
-	GPU_writeData((a1<<16)|(a0&0xffff));
-	GPU_writeData((a3<<16)|(a2&0xffff));
-	size = (a2*a3+1)/2;
+	GPU_writeData((a1<<0x10)|(a0&0xffff));
+	GPU_writeData((a3<<0x10)|(a2&0xffff));
+	size = ((((a2 * a3) / 2) >> 4) << 16);
 	GPU_writeStatus(0x04000002);
 	psxHwWrite32(0x1f8010f4,0);
 	psxHwWrite32(0x1f8010f0,psxHwRead32(0x1f8010f0)|0x800);
 	psxHwWrite32(0x1f8010a0,Rsp[4]);//might have a buggy...
-	psxHwWrite32(0x1f8010a4,((size/16)<<16)|16);
+	psxHwWrite32(0x1f8010a4, size | 0x10);
 	psxHwWrite32(0x1f8010a8,0x01000201);
 
 	pc0 = ra;
@@ -1454,22 +1454,26 @@ void psxBios_SendGPU() { // 0x48
 }
 
 void psxBios_GPU_cw() { // 0x49
+	gpuSyncPluginSR();
 	GPU_writeData(a0);
 	pc0 = ra;
+	v0 = HW_GPU_STATUS;
 }
 
 void psxBios_GPU_cwb() { // 0x4a
-	s32 *ptr = (s32*)Ra0;
+	u32 *ptr = (u32*)Ra0;
 	int size = a1;
-	while(size--) {
-		GPU_writeData(SWAP32(*ptr));
-		ptr++;
+	gpuSyncPluginSR();
+	while(size--)
+	{
+		GPU_writeData(SWAPu32(*ptr++));
 	}
 
 	pc0 = ra;
 }
    
 void psxBios_GPU_SendPackets() { //4b:	
+	gpuSyncPluginSR();
 	GPU_writeStatus(0x04000002);
 	psxHwWrite32(0x1f8010f4,0);
 	psxHwWrite32(0x1f8010f0,psxHwRead32(0x1f8010f0)|0x800);


### PR DESCRIPTION
See PCSX-Redux's openbios :
https://github.com/grumpycoders/pcsx-redux/blob/93653ba5281487d3bed57371d7b64c32dfc669f0/src/mips/openbios/gpu/gpu.c

That +1 for size was really triggering me, haha... (Pointer is also u32, according to OpenBIOS)
The original source code was based upon the disassembly of the source code by a Japanese user.