### PR TITLE
CDROM: Ignore sectors with channel number 255

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -1116,9 +1116,14 @@ void cdrReadInterrupt() {
 			cdr.Channel = cdr.Transfer[4 + 1];
 		}
 
+		/* Gameblabla 
+		 * Skips playing on channel 255.
+		 * Fixes missing audio in Blue's Clues : Blue's Big Musical. (Should also fix Taxi 2)
+		 * TODO : Check if this is the proper behaviour.
+		 * */
 		if((cdr.Transfer[4 + 2] & 0x4) &&
 			 (cdr.Transfer[4 + 1] == cdr.Channel) &&
-			 (cdr.Transfer[4 + 0] == cdr.File)) {
+			 (cdr.Transfer[4 + 0] == cdr.File) && cdr.Channel != 255) {
 			int ret = xa_decode_sector(&cdr.Xa, cdr.Transfer+4, cdr.FirstSector);
 			if (!ret) {
 				cdrAttenuate(cdr.Xa.pcm, cdr.Xa.nsamples, cdr.Xa.stereo);


### PR DESCRIPTION
This was inspired by the fix in Duckstation :
https://github.com/stenzek/duckstation/commit/0710e3b6d384526ed939f742f8f657623bb354bb

Some games have junk audio sectors with a channel number of 255.
If these are not skipped, then they will play wrong file.

This was tested on "Blue's Clues : Blue's Big Musical" and
it fixed the missing audio there.

Taxi 2 is also said to be affected by this.