### PR TITLE
Icache emulation from PCSX Redux + Senquack changes from PCSX4ALL

### DIFF
--- a/configure
+++ b/configure
@@ -59,6 +59,7 @@ need_sdl="no"
 need_xlib="no"
 need_libpicofe="yes"
 need_warm="no"
+enable_icache_emu="yes"
 CFLAGS_GLES=""
 LDLIBS_GLES=""
 # these are for known platforms
@@ -93,12 +94,14 @@ set_platform()
     optimize_cortexa8="yes"
     have_arm_neon="yes"
     need_xlib="yes"
+    enable_icache_emu="no"
     ;;
   maemo)
     ram_fixed="yes"
     drc_cache_base="yes"
     optimize_cortexa8="yes"
     have_arm_neon="yes"
+    enable_icache_emu="no"
     ;;
   caanoo)
     sound_drivers="oss"
@@ -106,6 +109,7 @@ set_platform()
     drc_cache_base="yes"
     optimize_arm926ej="yes"
     need_warm="yes"
+    enable_icache_emu="no"
     ;;
   libretro)
     sound_drivers="libretro"
@@ -134,6 +138,10 @@ for opt do
   ;;
   --disable-dynarec) enable_dynarec="no"
   ;;
+  --disable-icache-emu) enable_icache_emu="no"
+  ;;
+  --enable-icache-emu) enable_icache_emu="yes"
+  ;;
   *) echo "ERROR: unknown option $opt"; show_help="yes"
   ;;
   esac
@@ -152,6 +160,7 @@ if [ "$show_help" = "yes" ]; then
   echo "  --disable-neon           enable/disable ARM NEON optimizations [guessed]"
   echo "  --disable-dynarec        disable dynamic recompiler"
   echo "                           (dynarec is only available and enabled on ARM)"
+  echo "  --disable-icache-emu     Disables the instruction cache emulation"
   echo "influential environment variables:"
   echo "  CROSS_COMPILE CC CXX AS AR CFLAGS ASFLAGS LDFLAGS LDLIBS"
   exit 1
@@ -490,6 +499,10 @@ fi
 sizeof_long=`check_define_val __SIZEOF_LONG__`
 if [ "x$sizeof_long" = "x4" ]; then
   CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
+fi
+
+if [ "$enable_icache_emu" = "yes" ]; then
+  CFLAGS="$CFLAGS -DICACHE_EMULATION"
 fi
 
 cat > $TMPC <<EOF

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -122,7 +122,7 @@ void emu_set_default_config(void)
 {
 	// try to set sane config on which most games work
 	Config.Xa = Config.Cdda = Config.Sio =
-	Config.SpuIrq = Config.RCntFix = Config.VSyncWA = 0;
+	Config.icache_emulation = Config.SpuIrq = Config.RCntFix = Config.VSyncWA = 0;
 	Config.PsxAuto = 1;
 
 	pl_rearmed_cbs.gpu_neon.allow_interlace = 2; // auto

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -397,6 +397,7 @@ static const struct {
 	CE_CONFIG_VAL(SpuIrq),
 	CE_CONFIG_VAL(RCntFix),
 	CE_CONFIG_VAL(VSyncWA),
+	CE_CONFIG_VAL(icache_emulation),
 	CE_CONFIG_VAL(Cpu),
 	CE_INTVAL(region),
 	CE_INTVAL_V(g_scaler, 3),
@@ -1559,7 +1560,9 @@ static const char h_cfg_nodrc[]  = "Disable dynamic recompiler and use interpret
 				   "Might be useful to overcome some dynarec bugs";
 static const char h_cfg_shacks[] = "Breaks games but may give better performance\n"
 				   "must reload game for any change to take effect";
-
+static const char h_cfg_icache[] = "Allows you to play the F1 games.\n"
+				   "Note: This breaks the PAL version of Spyro 2.";
+				   
 static menu_entry e_menu_adv_options[] =
 {
 	mee_onoff_h   ("Show CPU load",          0, g_opts, OPT_SHOWCPU, h_cfg_cpul),
@@ -1569,6 +1572,9 @@ static menu_entry e_menu_adv_options[] =
 	mee_onoff_h   ("Disable CD Audio",       0, Config.Cdda, 1, h_cfg_cdda),
 	//mee_onoff_h   ("SIO IRQ Always Enabled", 0, Config.Sio, 1, h_cfg_sio),
 	mee_onoff_h   ("SPU IRQ Always Enabled", 0, Config.SpuIrq, 1, h_cfg_spuirq),
+#ifdef ICACHE_EMULATION
+	mee_onoff_h   ("ICache emulation",       0, Config.icache_emulation, 1, h_cfg_icache),
+#endif
 	//mee_onoff_h   ("Rootcounter hack",       0, Config.RCntFix, 1, h_cfg_rcnt1),
 	mee_onoff_h   ("Rootcounter hack 2",     0, Config.VSyncWA, 1, h_cfg_rcnt2),
 	mee_onoff_h   ("Disable dynarec (slow!)",0, Config.Cpu, 1, h_cfg_nodrc),

--- a/libpcsxcore/new_dynarec/emu_if.c
+++ b/libpcsxcore/new_dynarec/emu_if.c
@@ -393,6 +393,24 @@ static void ari64_clear(u32 addr, u32 size)
 			invalidate_block(start);
 }
 
+#ifdef ICACHE_EMULATION
+static void ari64_notify(int note, void *data) {
+	/*
+	Should be fixed when ARM dynarec has proper icache emulation.
+	switch (note)
+	{
+		case R3000ACPU_NOTIFY_CACHE_UNISOLATED:
+			break;
+		case R3000ACPU_NOTIFY_CACHE_ISOLATED:
+		Sent from psxDma3().
+		case R3000ACPU_NOTIFY_DMA3_EXE_LOAD:
+		default:
+			break;
+	}
+	*/
+}
+#endif
+
 static void ari64_shutdown()
 {
 	new_dynarec_cleanup();
@@ -419,6 +437,9 @@ R3000Acpu psxRec = {
 	intExecuteBlockT,
 #endif
 	ari64_clear,
+#ifdef ICACHE_EMULATION
+	ari64_notify,
+#endif
 	ari64_shutdown
 };
 

--- a/libpcsxcore/psxbios.c
+++ b/libpcsxcore/psxbios.c
@@ -1405,7 +1405,10 @@ void psxBios_FlushCache() { // 44
 #ifdef PSXBIOS_LOG
 	PSXBIOS_LOG("psxBios_%s\n", biosA0n[0x44]);
 #endif
-
+#ifdef ICACHE_EMULATION
+	psxCpu->Notify(R3000ACPU_NOTIFY_CACHE_ISOLATED, NULL);
+	psxCpu->Notify(R3000ACPU_NOTIFY_CACHE_UNISOLATED, NULL);
+#endif
 	pc0 = ra;
 }
 

--- a/libpcsxcore/psxcommon.h
+++ b/libpcsxcore/psxcommon.h
@@ -132,6 +132,7 @@ typedef struct {
 	boolean RCntFix;
 	boolean UseNet;
 	boolean VSyncWA;
+	boolean icache_emulation;
 	u8 Cpu; // CPU_DYNAREC or CPU_INTERPRETER
 	u8 PsxType; // PSX_TYPE_NTSC or PSX_TYPE_PAL
 #ifdef _WIN32

--- a/libpcsxcore/psxhw.c
+++ b/libpcsxcore/psxhw.c
@@ -44,7 +44,7 @@ void psxHwReset() {
 u8 psxHwRead8(u32 add) {
 	unsigned char hard;
 
-	switch (add) {
+	switch (add & 0x1fffffff) {
 		case 0x1f801040: hard = sioRead8();break; 
 #ifdef ENABLE_SIO1API
 		case 0x1f801050: hard = SIO1_readData8(); break;
@@ -70,7 +70,7 @@ u8 psxHwRead8(u32 add) {
 u16 psxHwRead16(u32 add) {
 	unsigned short hard;
 
-	switch (add) {
+	switch (add & 0x1fffffff) {
 #ifdef PSXHW_LOG
 		case 0x1f801070: PSXHW_LOG("IREG 16bit read %x\n", psxHu16(0x1070));
 			return psxHu16(0x1070);
@@ -204,7 +204,7 @@ u16 psxHwRead16(u32 add) {
 u32 psxHwRead32(u32 add) {
 	u32 hard;
 
-	switch (add) {
+	switch (add & 0x1fffffff) {
 		case 0x1f801040:
 			hard = sioRead8();
 			hard |= sioRead8() << 8;
@@ -355,7 +355,7 @@ u32 psxHwRead32(u32 add) {
 }
 
 void psxHwWrite8(u32 add, u8 value) {
-	switch (add) {
+	switch (add & 0x1fffffff) {
 		case 0x1f801040: sioWrite8(value); break;
 #ifdef ENABLE_SIO1API
 		case 0x1f801050: SIO1_writeData8(value); break;
@@ -379,7 +379,7 @@ void psxHwWrite8(u32 add, u8 value) {
 }
 
 void psxHwWrite16(u32 add, u16 value) {
-	switch (add) {
+	switch (add & 0x1fffffff) {
 		case 0x1f801040:
 			sioWrite8((unsigned char)value);
 			sioWrite8((unsigned char)(value>>8));
@@ -518,7 +518,7 @@ void psxHwWrite16(u32 add, u16 value) {
 }
 
 void psxHwWrite32(u32 add, u32 value) {
-	switch (add) {
+	switch (add & 0x1fffffff) {
 	    case 0x1f801040:
 			sioWrite8((unsigned char)value);
 			sioWrite8((unsigned char)((value&0xff) >>  8));

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -662,9 +662,9 @@ void psxSRL() { if (!_Rd_) return; _u32(_rRd_) = _u32(_rRt_) >> _Sa_; } // Rd = 
 * Shift arithmetic with variant register shift           *
 * Format:  OP rd, rt, rs                                 *
 *********************************************************/
-void psxSLLV() { if (!_Rd_) return; _u32(_rRd_) = _u32(_rRt_) << _u32(_rRs_); } // Rd = Rt << rs
-void psxSRAV() { if (!_Rd_) return; _i32(_rRd_) = _i32(_rRt_) >> _u32(_rRs_); } // Rd = Rt >> rs (arithmetic)
-void psxSRLV() { if (!_Rd_) return; _u32(_rRd_) = _u32(_rRt_) >> _u32(_rRs_); } // Rd = Rt >> rs (logical)
+void psxSLLV() { if (!_Rd_) return; _u32(_rRd_) = _u32(_rRt_) << (_u32(_rRs_) & 0x1F); } // Rd = Rt << rs
+void psxSRAV() { if (!_Rd_) return; _i32(_rRd_) = _i32(_rRt_) >> (_u32(_rRs_) & 0x1F); } // Rd = Rt >> rs (arithmetic)
+void psxSRLV() { if (!_Rd_) return; _u32(_rRd_) = _u32(_rRt_) >> (_u32(_rRs_) & 0x1F); } // Rd = Rt >> rs (logical)
 
 /*********************************************************
 * Load higher 16 bits of the first word in GPR with imm  *
@@ -691,7 +691,8 @@ void psxMTLO() { _rLo_ = _rRs_; } // Lo = Rs
 * Format:  OP                                            *
 *********************************************************/
 void psxBREAK() {
-	// Break exception - psx rom doens't handles this
+	psxRegs.pc -= 4;
+	psxException(0x24, branch);
 }
 
 void psxSYSCALL() {
@@ -703,6 +704,7 @@ void psxRFE() {
 //	SysPrintf("psxRFE\n");
 	psxRegs.CP0.n.Status = (psxRegs.CP0.n.Status & 0xfffffff0) |
 						  ((psxRegs.CP0.n.Status & 0x3c) >> 2);
+	psxTestSWInts();
 }
 
 /*********************************************************
@@ -726,14 +728,14 @@ void psxJAL() {	_SetLink(31); doBranch(_JumpTarget_); }
 * Format:  OP rs, rd                                     *
 *********************************************************/
 void psxJR()   {
-	doBranch(_u32(_rRs_));
+	doBranch(_rRs_ & ~3);
 	psxJumpTest();
 }
 
 void psxJALR() {
 	u32 temp = _u32(_rRs_);
 	if (_Rd_) { _SetLink(_Rd_); }
-	doBranch(temp);
+	doBranch(temp & ~3);
 }
 
 /*********************************************************

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -641,7 +641,7 @@ void psxMULTU() {
 * Format:  OP rs, offset                                 *
 *********************************************************/
 #define RepZBranchi32(op)      if(_i32(_rRs_) op 0) doBranch(_BranchTarget_);
-#define RepZBranchLinki32(op)  if(_i32(_rRs_) op 0) { _SetLink(31); doBranch(_BranchTarget_); }
+#define RepZBranchLinki32(op)  { _SetLink(31); if(_i32(_rRs_) op 0) { doBranch(_BranchTarget_); } }
 
 void psxBGEZ()   { RepZBranchi32(>=) }      // Branch if Rs >= 0
 void psxBGEZAL() { RepZBranchLinki32(>=) }  // Branch if Rs >= 0 and link

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -236,7 +236,7 @@ u8 psxMemRead8(u32 mem) {
 #ifdef PSXMEM_LOG
 			PSXMEM_LOG("err lb %8.8lx\n", mem);
 #endif
-			return 0;
+			return 0xFF;
 		}
 	}
 }
@@ -261,7 +261,7 @@ u16 psxMemRead16(u32 mem) {
 #ifdef PSXMEM_LOG
 			PSXMEM_LOG("err lh %8.8lx\n", mem);
 #endif
-			return 0;
+			return 0xFFFF;
 		}
 	}
 }
@@ -286,7 +286,7 @@ u32 psxMemRead32(u32 mem) {
 #ifdef PSXMEM_LOG
 			if (writeok) { PSXMEM_LOG("err lw %8.8lx\n", mem); }
 #endif
-			return 0;
+			return 0xFFFFFFFF;
 		}
 	}
 }

--- a/libpcsxcore/r3000a.h
+++ b/libpcsxcore/r3000a.h
@@ -29,12 +29,24 @@ extern "C" {
 #include "psxcounters.h"
 #include "psxbios.h"
 
+#ifdef ICACHE_EMULATION
+enum {
+	R3000ACPU_NOTIFY_CACHE_ISOLATED = 0,
+	R3000ACPU_NOTIFY_CACHE_UNISOLATED = 1,
+	R3000ACPU_NOTIFY_DMA3_EXE_LOAD = 2
+};
+extern uint32_t *Read_ICache(uint32_t pc);
+#endif
+
 typedef struct {
 	int  (*Init)();
 	void (*Reset)();
 	void (*Execute)();		/* executes up to a break */
 	void (*ExecuteBlock)();	/* executes up to a jump */
 	void (*Clear)(u32 Addr, u32 Size);
+#ifdef ICACHE_EMULATION
+	void (*Notify)(int note, void *data);
+#endif
 	void (*Shutdown)();
 } R3000Acpu;
 


### PR DESCRIPTION
See (Redux) :
https://github.com/grumpycoders/pcsx-redux/commit/1923ce54ef585beba3a948d50f8c30161102312c

See original icache implementation (mirror of PCSX Reloaded):
https://github.com/gameblabla/pcsxr

Without icache emulation, F1 2001 will greatly misbehave :
if you accelerate, the car will go around like crazy.
With icache emulation, it works as intended.

Our code is slightly different from theirs as i found out that having the icache arrays in psxregs would cause crashes.
Instead, i'm taking them out of there and only allocating them on the heap (due to their great size).

I'm open for suggestions. For example, should i put writeok in Psxregs or out of it ?

**EDIT**: I should point out this doesn't add icache emulation for the ARM dynarec. That will need to be done by someone else.