### PR TITLE
Don't throw an error for CdlGetQ.

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -902,8 +902,7 @@ void cdrInterrupt() {
 			break;
 
 		case CdlGetQ:
-			// TODO?
-			CDR_LOG_I("got CdlGetQ\n");
+			no_busy_error = 1;
 			break;
 
 		case CdlReadToc:


### PR DESCRIPTION
I doubt this is used by any games but who knows.

See Mednafen for reference :
https://github.com/libretro-mirrors/mednafen-git/blob/1899500078169e787f86eb5302a3f35abdaa8764/src/psx/cdc.cpp#L2527