### PR TITLE
Improve CdlPause command based on Mednafen's implementation

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -722,7 +722,17 @@ void cdrInterrupt() {
 			InuYasha - Feudal Fairy Tale: slower
 			- Fixes battles
 			*/
-			AddIrqQueue(CdlPause + 0x100, cdReadTime * 3);
+			/* Gameblabla - Tightening the timings (as taken from Mednafen). */
+			if (cdr.DriveState != DRIVESTATE_STANDBY)
+			{
+				delay = 5000;
+			}
+			else
+			{
+				delay = (1124584 + (msf2sec(cdr.SetSectorPlay) * 42596 / (75 * 60))) * ((cdr.Mode & MODE_SPEED) ? 1 : 2);
+				CDRMISC_INT((cdr.Mode & MODE_SPEED) ? cdReadTime / 2 : cdReadTime);
+			}
+			AddIrqQueue(CdlPause + 0x100, delay);
 			cdr.Ctrl |= 0x80;
 			break;
 


### PR DESCRIPTION
Reference :
https://github.com/libretro-mirrors/mednafen-git/blob/master/src/psx/cdc.cpp#L1969

**EDIT**: I originally added a comment saying that it allowed Worms Pinball to more reliably boot to the language screen.
While the game does use the CdlPause command, it would still sometimes crash : /. Seems to be an oversight in gpulib.