### PR TITLE
Fix regression with CdlPause

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -722,14 +722,18 @@ void cdrInterrupt() {
 			InuYasha - Feudal Fairy Tale: slower
 			- Fixes battles
 			*/
-			/* Gameblabla - Tightening the timings (as taken from Mednafen). */
+			/* Gameblabla - Tightening the timings (as taken from Duckstation). 
+			 * The timings from Duckstation are based upon hardware tests.
+			 * Mednafen's timing don't work for Gundam Battle Assault 2 in PAL/50hz mode,
+			 * seems to be timing sensitive as it can depend on the CPU's clock speed.
+			 * */
 			if (cdr.DriveState != DRIVESTATE_STANDBY)
 			{
-				delay = 5000;
+				delay = 7000;
 			}
 			else
 			{
-				delay = (1124584 + (msf2sec(cdr.SetSectorPlay) * 42596 / (75 * 60))) * ((cdr.Mode & MODE_SPEED) ? 1 : 2);
+				delay = (((cdr.Mode & MODE_SPEED) ? 2 : 1) * (1000000));
 				CDRMISC_INT((cdr.Mode & MODE_SPEED) ? cdReadTime / 2 : cdReadTime);
 			}
 			AddIrqQueue(CdlPause + 0x100, delay);


### PR DESCRIPTION
As i noted in https://github.com/notaz/pcsx_rearmed/pull/207#issuecomment-907510653,
my last PR broke Gundam Battle Assault 2 for the PAL version. (also affects the NTSC version if booted in PAL mode)
The cdlpause changes from Mednafen were intended so i could possibly look into fixing Rise 2/Bedlam (as Duckstation code implemented async reading also, so it's kind of all over the place) but for now, they are not quite accurate and i have been told duckstation's "magic numbers" were gotten from hardware tests.
(which i assume, [were noted down here](https://github.com/JaCzekanski/ps1-tests/blob/master/cdrom/timing/psx.log))

Until Mednafen looks around it, let's just use a simplier fix. (and yes, i've tried it with all the 3 games that were noted down in the comments and they all work fine in both NTSC and PAL)