### PR TITLE
ARM build fixes. (Fixes building on ARM/GCC10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,7 @@ ifeq "$(USE_DYNAREC)" "1"
 OBJS += libpcsxcore/new_dynarec/new_dynarec.o libpcsxcore/new_dynarec/linkage_arm.o
 OBJS += libpcsxcore/new_dynarec/pcsxmem.o
 else
-libpcsxcore/new_dynarec/emu_if.o: CFLAGS += -DDRC_DISABLE
-frontend/libretro.o: CFLAGS += -DDRC_DISABLE
+CFLAGS += -DDRC_DISABLE
 endif
 OBJS += libpcsxcore/new_dynarec/emu_if.o
 libpcsxcore/new_dynarec/new_dynarec.o: libpcsxcore/new_dynarec/assem_arm.c \

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2585,7 +2585,11 @@ void menu_prepare_emu(void)
 
 	plat_video_menu_leave();
 
+	#ifndef DRC_DISABLE
 	psxCpu = (Config.Cpu == CPU_INTERPRETER) ? &psxInt : &psxRec;
+	#else
+	psxCpu = &psxInt;
+	#endif
 	if (psxCpu != prev_cpu) {
 		prev_cpu->Shutdown();
 		psxCpu->Init();

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -745,7 +745,7 @@ int RecvPcsxInfo() {
 	NET_recvData(&Config.Cpu, sizeof(Config.Cpu), PSE_NET_BLOCKING);
 	if (tmp != Config.Cpu) {
 		psxCpu->Shutdown();
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 		if (Config.Cpu == CPU_INTERPRETER) psxCpu = &psxInt;
 		else psxCpu = &psxRec;
 #else

--- a/libpcsxcore/new_dynarec/new_dynarec.c
+++ b/libpcsxcore/new_dynarec/new_dynarec.c
@@ -3441,6 +3441,7 @@ void syscall_assemble(int i,struct regstat *i_regs)
 
 void hlecall_assemble(int i,struct regstat *i_regs)
 {
+  extern void psxNULL();
   signed char ccreg=get_reg(i_regs->regmap,CCREG);
   assert(ccreg==HOST_CCREG);
   assert(!is_delayslot);

--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -66,9 +66,9 @@ static const u32 HSyncTotal[]     = { 263, 313 };
 #define VERBOSE_LEVEL 0
 
 /******************************************************************************/
-
+#ifdef DRC_DISABLE
 Rcnt rcnts[ CounterQuantity ];
-
+#endif
 u32 hSyncCount = 0;
 u32 frame_counter = 0;
 static u32 hsync_steps = 0;
@@ -493,7 +493,7 @@ s32 psxRcntFreeze( void *f, s32 Mode )
     u32 count;
     s32 i;
 
-    gzfreeze( &rcnts, sizeof(rcnts) );
+    gzfreeze( &rcnts, sizeof(Rcnt) * CounterQuantity );
     gzfreeze( &hSyncCount, sizeof(hSyncCount) );
     gzfreeze( &spuSyncCount, sizeof(spuSyncCount) );
     gzfreeze( &psxNextCounter, sizeof(psxNextCounter) );

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -307,7 +307,7 @@ void psxMemWrite8(u32 mem, u8 value) {
 			if (Config.Debug)
 				DebugCheckBP((mem & 0xffffff) | 0x80000000, W1);
 			*(u8 *)(p + (mem & 0xffff)) = value;
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 			psxCpu->Clear((mem & (~3)), 1);
 #endif
 		} else {
@@ -334,7 +334,7 @@ void psxMemWrite16(u32 mem, u16 value) {
 			if (Config.Debug)
 				DebugCheckBP((mem & 0xffffff) | 0x80000000, W2);
 			*(u16 *)(p + (mem & 0xffff)) = SWAPu16(value);
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 			psxCpu->Clear((mem & (~3)), 1);
 #endif
 		} else {
@@ -362,12 +362,12 @@ void psxMemWrite32(u32 mem, u32 value) {
 			if (Config.Debug)
 				DebugCheckBP((mem & 0xffffff) | 0x80000000, W4);
 			*(u32 *)(p + (mem & 0xffff)) = SWAPu32(value);
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 			psxCpu->Clear(mem, 1);
 #endif
 		} else {
 			if (mem != 0xfffe0130) {
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 				if (!writeok)
 					psxCpu->Clear(mem, 1);
 #endif

--- a/libpcsxcore/psxmem.h
+++ b/libpcsxcore/psxmem.h
@@ -122,10 +122,6 @@ extern u8 **psxMemRLUT;
 
 #define PSXMu32ref(mem)	(*(u32 *)PSXM(mem))
 
-#if !defined(PSXREC) && (defined(__x86_64__) || defined(__i386__) || defined(__ppc__)) && !defined(NOPSXREC)
-#define PSXREC
-#endif
-
 int psxMemInit();
 void psxMemReset();
 void psxMemShutdown();

--- a/libpcsxcore/r3000a.c
+++ b/libpcsxcore/r3000a.c
@@ -27,12 +27,14 @@
 #include "gte.h"
 
 R3000Acpu *psxCpu = NULL;
+#ifdef DRC_DISABLE
 psxRegisters psxRegs;
+#endif
 
 int psxInit() {
 	SysPrintf(_("Running PCSX Version %s (%s).\n"), PACKAGE_VERSION, __DATE__);
 
-#ifdef PSXREC
+#ifndef DRC_DISABLE
 	if (Config.Cpu == CPU_INTERPRETER) {
 		psxCpu = &psxInt;
 	} else psxCpu = &psxRec;

--- a/libpcsxcore/r3000a.h
+++ b/libpcsxcore/r3000a.h
@@ -41,7 +41,6 @@ typedef struct {
 extern R3000Acpu *psxCpu;
 extern R3000Acpu psxInt;
 extern R3000Acpu psxRec;
-#define PSXREC
 
 typedef union {
 #if defined(__BIGENDIAN__)


### PR DESCRIPTION
This fixes building on GCC10 and ARM. (the GCC10 fix is based upon libretro's fix : https://github.com/libretro/pcsx_rearmed/pull/466.
Note that in my previous HLE patch, i forgot to export psxNULL so it was failling to compile it... Oops.