### PR TITLE
Fix for internal crash when height is too low

### DIFF
--- a/frontend/plugin_lib.c
+++ b/frontend/plugin_lib.c
@@ -257,10 +257,15 @@ static void pl_vout_set_mode(int w, int h, int raw_w, int raw_h, int bpp)
 	if (pl_rearmed_cbs.only_16bpp)
 		vout_bpp = 16;
 
-	// don't use very low heights
-	if (vout_h < 192) {
-		buf_yoffset = (192 - vout_h) / 2;
-		vout_h = 192;
+	/* Gameblabla :
+	 * For some strange reasons, Sim Theme Park and Alundra 2 both try to set a low height resolution.
+	 * In the case of Alundra 2, it sets it to 128x32 and in the case of Sim Theme Park, it's 320x176.
+	 * If you don't allow these games to go below 192 for the height (as it was set before), then the games will do
+	 * an internal crash. (either during SDL_Flip, or when setting the new resolution with SDL_SetVideoMode)
+	 * */
+	if (vout_h < 32) {
+		buf_yoffset = (32 - vout_h) / 2;
+		vout_h = 32;
 	}
 
 	pl_vout_scale_w = pl_vout_scale_h = 1;


### PR DESCRIPTION
Multiple games like Sim Theme Park and Alundra 2 would make the software renderers and the SDL mode crash
because they request a height that is too low and eventually causes an internal crash in libpicofe.

There was a mysterious comment that said that low heights should not be allowed.
However, i don't see a reason why this should be done for SDL Window.
I should point out that this bug doesn't affect the OpenGL mode and it seemingly doesn't affect libretro either.

It seems that the games use DISPENV.screen struct for that purpose
and the real hardware would still display it as 320x224, just centered.

This is what Sim Theme Park would trigger without the fix :
```
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
49	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
#1  0x00007ffff7a66536 in __GI_abort () at abort.c:79
#2  0x00007ffff7abe4f8 in __libc_message (action=action@entry=do_abort, 
    fmt=fmt@entry=0x7ffff7bcdb7f "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#3  0x00007ffff7ac5f3a in malloc_printerr (
    str=str@entry=0x7ffff7bd0090 "double free or corruption (!prev)")
    at malloc.c:5389
#4  0x00007ffff7ac77ac in _int_free (av=0x7ffff7bffa00 <main_arena>, 
    p=0x5555559f7aa0, have_lock=<optimized out>) at malloc.c:4350
#5  0x00007ffff7f61555 in SDL_FreeSurface () from /usr/lib/libSDL-1.2.so.0
#6  0x00007ffff7f63b16 in SDL_SetVideoMode () from /usr/lib/libSDL-1.2.so.0
#7  0x00005555555ba8ba in plat_sdl_change_video_mode (w=256, h=240, 
    force=force@entry=0) at frontend/libpicofe/plat_sdl.c:123
#8  0x00005555555bc2a1 in change_video_mode (force=0)
    at frontend/plat_sdl.c:108
#9  plat_gvideo_set_mode (w=w@entry=0x7fffffffd61c, h=h@entry=0x7fffffffd620, 
    bpp=bpp@entry=0x7fffffffd624) at frontend/plat_sdl.c:233
#10 0x00005555555bd1d3 in pl_vout_set_mode (w=<optimized out>, 
    h=<optimized out>, raw_w=<optimized out>, raw_h=<optimized out>, 
    bpp=<optimized out>) at frontend/plugin_lib.c:292
#11 0x000055555559ebac in vout_update () at plugins/gpulib/vout_pl.c:68
#12 0x000055555559e8a7 in GPUupdateLace () at plugins/gpulib/gpu.c:696
#13 0x0000555555586f49 in psxRcntUpdate () at libpcsxcore/psxcounters.c:335
```

Alundra 2 would instead crash at SDL_Flip.