### PR TITLE
Vampire Hunter D : GPU DMA hack lifted from PCSX Reloaded

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -122,7 +122,7 @@ void emu_set_default_config(void)
 {
 	// try to set sane config on which most games work
 	Config.Xa = Config.Cdda = Config.Sio =
-	Config.SpuIrq = Config.RCntFix = Config.VSyncWA = 0;
+	Config.VampireHunterHack = Config.SpuIrq = Config.RCntFix = Config.VSyncWA = 0;
 	Config.PsxAuto = 1;
 
 	pl_rearmed_cbs.gpu_neon.allow_interlace = 2; // auto

--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -17,10 +17,22 @@ static const char MemorycardHack_db[8][10] =
 	{"SCUS94409"}
 };
 
+static const char VampireHunter_DMA_hack[6][10] =
+{
+	{"SLUS01138"},
+	{"SLPS02477"},
+	{"SLES02731"},
+	{"SLPS03198"},
+	{"SLPS91523"}
+};
+
 /* Function for automatic patching according to GameID. */
 void Apply_Hacks_Cdrom()
 {
 	uint32_t i;
+	
+	// Disable for other games
+	Config.VampireHunterHack = 0;
 	
 	/* Apply Memory card hack for Codename Tenka. (The game needs one of the memory card slots to be empty) */
 	for(i=0;i<ARRAY_SIZE(MemorycardHack_db);i++)
@@ -31,6 +43,15 @@ void Apply_Hacks_Cdrom()
 			Config.Mcd2[0] = 0;
 			/* This also needs to be done because in sio.c, they don't use Config.Mcd2 for that purpose */
 			McdDisable[1] = 1;
+		}
+	}
+	
+	/* Use GPU DMA hack to fix Vampire Hunter's black screen during titlescreen (lifted from PCSX Reloaded) */
+	for(i=0;i<ARRAY_SIZE(MemorycardHack_db);i++)
+	{
+		if (strncmp(CdromId, VampireHunter_DMA_hack[i], 9) == 0)
+		{
+			Config.VampireHunterHack = 1;
 		}
 	}
 }

--- a/libpcsxcore/psxcommon.h
+++ b/libpcsxcore/psxcommon.h
@@ -132,6 +132,7 @@ typedef struct {
 	boolean RCntFix;
 	boolean UseNet;
 	boolean VSyncWA;
+	boolean VampireHunterHack;
 	u8 Cpu; // CPU_DYNAREC or CPU_INTERPRETER
 	u8 PsxType; // PSX_TYPE_NTSC or PSX_TYPE_PAL
 #ifdef _WIN32


### PR DESCRIPTION
Game suffers from tight CPU/DMA timings.
A hack was used for PCSX Reloaded. 
However, it affects other games and breaks the water in Tomb Raider 2 so let's use the internal database for that purpose and only enable it for this game.

So yes, we removed an SPU hack for Diablo to introduce yet another game hack for a game : P.
I should point out that this only affects the titlescreen of Vampire Hunter D : the game is playable otherwise even without the game. (but people get confused when the black screen issue happen and think the game hanged or froze)

I should also mention that this hack works in real time as well and the titlescreen will go back to being black if disabled.