### PR TITLE
Merge several fixes from PCSX Redux and adjust delay for SetLocPending.

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -1599,12 +1599,12 @@ static void DecodeRawSubData(void) {
 // read track
 // time: byte 0 - minute; byte 1 - second; byte 2 - frame
 // uses bcd format
-static long CALLBACK ISOreadTrack(unsigned char *time) {
+static boolean CALLBACK ISOreadTrack(unsigned char *time) {
 	int sector = MSF2SECT(btoi(time[0]), btoi(time[1]), btoi(time[2]));
 	long ret;
 
 	if (cdHandle == NULL) {
-		return -1;
+		return 0;
 	}
 
 	if (pregapOffset) {
@@ -1618,7 +1618,7 @@ static long CALLBACK ISOreadTrack(unsigned char *time) {
 
 	ret = cdimg_read_func(cdHandle, 0, cdbuffer, sector);
 	if (ret < 0)
-		return -1;
+		return 0;
 
 	if (subHandle != NULL) {
 		fseek(subHandle, sector * SUB_FRAMESIZE, SEEK_SET);
@@ -1627,7 +1627,7 @@ static long CALLBACK ISOreadTrack(unsigned char *time) {
 		if (subChanRaw) DecodeRawSubData();
 	}
 
-	return 0;
+	return 1;
 }
 
 // plays cdda audio

--- a/libpcsxcore/cdrom.h
+++ b/libpcsxcore/cdrom.h
@@ -91,7 +91,7 @@ typedef struct {
 	int CurTrack;
 	int Mode, File, Channel;
 	int Reset;
-	int RErr;
+	int NoErr;
 	int FirstSector;
 
 	xa_decode_t Xa;

--- a/libpcsxcore/plugins.h
+++ b/libpcsxcore/plugins.h
@@ -123,7 +123,7 @@ typedef long (CALLBACK* CDRopen)(void);
 typedef long (CALLBACK* CDRclose)(void);
 typedef long (CALLBACK* CDRgetTN)(unsigned char *);
 typedef long (CALLBACK* CDRgetTD)(unsigned char, unsigned char *);
-typedef long (CALLBACK* CDRreadTrack)(unsigned char *);
+typedef boolean (CALLBACK* CDRreadTrack)(unsigned char *);
 typedef unsigned char* (CALLBACK* CDRgetBuffer)(void);
 typedef unsigned char* (CALLBACK* CDRgetBufferSub)(void);
 typedef long (CALLBACK* CDRconfigure)(void);


### PR DESCRIPTION
There's a game, PoPoLoCrois Monogatari II, that unfortunately locks up during the intro screen.
I should have known that code was wrong as Mednafen did not have anything like that in their code either, hence the confusion.

Their fix however still don't include the Driver fix so the game would still crash if we don't have the "+ Seektime".
To be honest, i'm not sure why the PCSX Reloaded team did it this way...
In any case, i adjusted it so it doesn't mess up the audio for Driver's titlescreen and doesn't crash in Worms Pinball either.
Seems like setting it to 100000 was not enough for that game.

I noticed the fastword and FastBackward were not being used in any way.
Looked at Mednafen and all they do is just adjust the cursector
and make sure that fastword & backword trigger the AUTO_REPORT code so i did the latter.

There was also a mysterious leftover code from PCSX Reloaded in Cdlplay:
that had a condition that forced it to SEEK_DONE (with a comment even saying that it should be set to SEEK instead) so i set it to SEEK_PENDING instead.
(Mednafen's code seems to suggest so as well)

I could not notice a game that has regressed so far. (i also have tested the Driver retry mission thing and it still works)
This fixes the lockup in PoPoLoCrois Monogatari II when starting a new game. (this still doesn't fix the missing audio in that game but we'll get around it eventually)