### PR TITLE
Fix detection of some CDs such as Wild Arms USA detected as a PAL game.

### DIFF
--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -379,7 +379,13 @@ int CheckCdrom() {
 		strcpy(CdromId, "SLUS99999");
 
 	if (Config.PsxAuto) { // autodetect system (pal or ntsc)
-		if (CdromId[2] == 'e' || CdromId[2] == 'E')
+		if (
+			/* Make sure Wild Arms SCUS-94608 is not detected as a PAL game. */
+			((CdromId[0] == 's' || CdromId[0] == 'S') && (CdromId[2] == 'e' || CdromId[2] == 'E')) ||
+			!strncmp(CdromId, "DTLS3035", 8) ||
+			!strncmp(CdromId, "PBPX95001", 9) || // according to redump.org, these PAL
+			!strncmp(CdromId, "PBPX95007", 9) || // discs have a non-standard ID;
+			!strncmp(CdromId, "PBPX95008", 9))   // add more serials if they are discovered.
 			Config.PsxType = PSX_TYPE_PAL; // pal
 		else Config.PsxType = PSX_TYPE_NTSC; // ntsc
 	}


### PR DESCRIPTION
This also fix the detection of some obscure game.
Both fixes were taken from another fork of PCSX4ALL and PCSX Reloaded.

I was able to confirm it fixed the issue for Wild Arms USA.

The PCSX Reloaded fix mentioned that notaz broke the obscure games... : P
https://github.com/gameblabla/pcsxr/commit/c305bd479c0d4233bf4106401e0b64cd5f12be0b

Here's the original fix from PCSX4ALL :
https://github.com/jdgleaver/RG350_pcsx4all/commit/c96751d43ff6373dda49b87a296df7cafffa5461

There is probably a cleaner way though.