### PR TITLE
Fix for Armored Core misdetecting a Link cable being detected

### DIFF
--- a/libpcsxcore/psxhw.c
+++ b/libpcsxcore/psxhw.c
@@ -124,6 +124,13 @@ u16 psxHwRead16(u32 add) {
 		case 0x1f80105e:
 			hard = SIO1_readBaud16();
 			return hard;
+#else
+		/* Fixes Armored Core misdetecting the Link cable being detected.
+		 * We want to turn that thing off and force it to do local multiplayer instead.
+		 * Thanks Sony for the fix, they fixed it in their PS Classic fork.
+		 */
+		case 0x1f801054:
+			return 0x80;
 #endif
 		case 0x1f801100:
 			hard = psxRcntRcount(0);


### PR DESCRIPTION
For some reason, the game detects that a link cable is plugged in
and disables the local multiplayer as a result.

Thanks @sony for fixing the issue in their PS Classic branch, a simpler fix is done here instead.

**Unfixed**
![armored_core_unfixed](https://user-images.githubusercontent.com/8717966/135701174-e81bd6c6-3865-406a-9f16-e1b28ea0fd8f.png)

**Fixed**
![armored_core_fixed](https://user-images.githubusercontent.com/8717966/135701178-eaa40ecf-7462-4cb4-8b70-e414f52ba685.png)


