### PR TITLE
One more on odd lines for PAL (HSYNC)

### DIFF
--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -60,7 +60,7 @@ static const u32 CountToOverflow  = 0;
 static const u32 CountToTarget    = 1;
 
 static const u32 FrameRate[]      = { 60, 50 };
-static const u32 HSyncTotal[]     = { 263, 313 };
+static const u32 HSyncTotal[]     = { 263, 314 }; // actually one more on odd lines for PAL
 #define VBlankStart 240
 
 #define VERBOSE_LEVEL 0


### PR DESCRIPTION
As done by Duckstation
https://github.com/stenzek/duckstation/blob/bbcf1c67d1aefd5de9cdc9c158f92bc7aaecaa63/src/core/gpu.h#L56

Mednafen also sets it to 314 and has some more explanation about it :
https://github.com/libretro-mirrors/mednafen-git/blob/1899500078169e787f86eb5302a3f35abdaa8764/src/psx/gpu.cpp#L44