### PR TITLE
Use u8 instead of s8 for psxM, psxP, psxR, psxH

### DIFF
--- a/libpcsxcore/psxbios.c
+++ b/libpcsxcore/psxbios.c
@@ -3319,7 +3319,7 @@ void psxBiosException() {
 
 #define bfreezepsxMptr(ptr, type) { \
 	if (Mode == 1) { \
-		if (ptr) psxRu32ref(base) = SWAPu32((s8 *)(ptr) - psxM); \
+		if (ptr) psxRu32ref(base) = SWAPu32((u8 *)(ptr) - psxM); \
 		else psxRu32ref(base) = 0; \
 	} else { \
 		if (psxRu32(base) != 0) ptr = (type *)(psxM + psxRu32(base)); \

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -100,10 +100,10 @@ void psxUnmap(void *ptr, size_t size, enum psxMapTag tag)
 		munmap(ptr, size);
 }
 
-s8 *psxM = NULL; // Kernel & User Memory (2 Meg)
-s8 *psxP = NULL; // Parallel Port (64K)
-s8 *psxR = NULL; // BIOS ROM (512K)
-s8 *psxH = NULL; // Scratch Pad (1K) & Hardware Registers (8K)
+u8 *psxM = NULL; // Kernel & User Memory (2 Meg)
+u8 *psxP = NULL; // Parallel Port (64K)
+u8 *psxR = NULL; // BIOS ROM (512K)
+u8 *psxH = NULL; // Scratch Pad (1K) & Hardware Registers (8K)
 
 u8 **psxMemWLUT = NULL;
 u8 **psxMemRLUT = NULL;

--- a/libpcsxcore/psxmem.h
+++ b/libpcsxcore/psxmem.h
@@ -49,7 +49,7 @@ extern "C" {
 
 #endif
 
-extern s8 *psxM;
+extern u8 *psxM;
 #define psxMs8(mem)		psxM[(mem) & 0x1fffff]
 #define psxMs16(mem)	(SWAP16(*(s16 *)&psxM[(mem) & 0x1fffff]))
 #define psxMs32(mem)	(SWAP32(*(s32 *)&psxM[(mem) & 0x1fffff]))
@@ -64,7 +64,7 @@ extern s8 *psxM;
 #define psxMu16ref(mem)	(*(u16 *)&psxM[(mem) & 0x1fffff])
 #define psxMu32ref(mem)	(*(u32 *)&psxM[(mem) & 0x1fffff])
 
-extern s8 *psxP;
+extern u8 *psxP;
 #define psxPs8(mem)	    psxP[(mem) & 0xffff]
 #define psxPs16(mem)	(SWAP16(*(s16 *)&psxP[(mem) & 0xffff]))
 #define psxPs32(mem)	(SWAP32(*(s32 *)&psxP[(mem) & 0xffff]))
@@ -79,7 +79,7 @@ extern s8 *psxP;
 #define psxPu16ref(mem)	(*(u16 *)&psxP[(mem) & 0xffff])
 #define psxPu32ref(mem)	(*(u32 *)&psxP[(mem) & 0xffff])
 
-extern s8 *psxR;
+extern u8 *psxR;
 #define psxRs8(mem)		psxR[(mem) & 0x7ffff]
 #define psxRs16(mem)	(SWAP16(*(s16 *)&psxR[(mem) & 0x7ffff]))
 #define psxRs32(mem)	(SWAP32(*(s32 *)&psxR[(mem) & 0x7ffff]))
@@ -94,7 +94,7 @@ extern s8 *psxR;
 #define psxRu16ref(mem)	(*(u16*)&psxR[(mem) & 0x7ffff])
 #define psxRu32ref(mem)	(*(u32*)&psxR[(mem) & 0x7ffff])
 
-extern s8 *psxH;
+extern u8 *psxH;
 #define psxHs8(mem)		psxH[(mem) & 0xffff]
 #define psxHs16(mem)	(SWAP16(*(s16 *)&psxH[(mem) & 0xffff]))
 #define psxHs32(mem)	(SWAP32(*(s32 *)&psxH[(mem) & 0xffff]))


### PR DESCRIPTION
Use an unsigned char for psxM, psxP, psxR, psxH instead of a signed char.
Any reasons why PCSX reloaded used signed chars ? (i noticed they used s8 too)
To be fair GCC and Clang are probably clever enough to do it to not care about it but this could avoid an issue where chars could be unsigned instead. (not that it wouldn't work if it did happen but in general i only use char for text and stuff)

