### PR TITLE
Hack fix stutter before speech samples in Castlevania Symphony of the Night

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -1183,6 +1183,19 @@ void cdrReadInterrupt() {
 			int ret = xa_decode_sector(&cdr.Xa, cdr.Transfer+4, cdr.FirstSector);
 			if (!ret) {
 				cdrAttenuate(cdr.Xa.pcm, cdr.Xa.nsamples, cdr.Xa.stereo);
+				/*
+				 * Gameblabla -
+				 * This is a hack for Megaman X4, Castlevania etc...
+				 * that regressed from the new m_locationChanged and CDROM timings changes.
+				 * It is mostly noticeable in Castevania however and the stuttering can be very jarring.
+				 * 
+				 * According to PCSX redux authors, we shouldn't cause a location change if
+				 * the sector difference is too small. 
+				 * I attempted to go with that approach but came empty handed.
+				 * So for now, let's just set cdr.m_locationChanged to false when playing back any ADPCM samples.
+				 * This does not regress Crash Team Racing's intro at least.
+				*/
+				cdr.m_locationChanged = FALSE;
 				SPU_playADPCMchannel(&cdr.Xa);
 				cdr.FirstSector = 0;
 			}


### PR DESCRIPTION
A regression was introduced by the CDROM timings changes
https://github.com/notaz/pcsx_rearmed/commit/dc0ee8d424293ea687a137ec1ca0440f88a1e5a5

This was done to fix some games such as :
- Crash Team Racing's intro music cutting off too soon
- FF8 Lunar Cry FMV freeze (Disc 3)
- Worms Pinball not booting
- Xenogears (Deus fight)

However for whatever reason, this also caused ADPCM speech samples
in Castlevania Symphony of the Night to stutter.

This could be caused by another underlying issue however.
Here are the commands being run by Castlevania for speech samples :

```
CD1 write: 1 (CdlNop)
CD1 write: 1 (CdlNop)
CD1 write: 9 (CdlPause)
CD1 write: e (CdlSetmode) Param[1] = { c8,}
CD1 write: 1 (CdlNop)
CD1 write: d (CdlSetfilter) Param[2] = { b, 6,}
CD1 write: 1 (CdlNop)
CD1 write: 2 (CdlSetloc) Param[3] = { 26, 1, 39,}
CD1 write: 1 (CdlNop)
CD1 write: 6 (CdlReadN)
CD1 write: 1 (CdlNop)
```

In nocash's documentation, they mention that the Setfilter command only affects ADPCM sectors.
I wonder if this is related ??

I will complain to PCSX Redux about it (as the issue also happens here as well)
Sadly the CDROM code as it is is hopelessly broken... :/

I opened a bug report in PCSX Redux as they also have the same issue after they merged said changes too
https://github.com/grumpycoders/pcsx-redux/issues/643

Videos (recorded with PCSX Redux but also affects PCSX Rearmed) :
Before fix :  https://youtu.be/g6sT0DggNRI 
After fix :  https://youtu.be/TIbi3nRH6xw 