### PR TITLE
Fix CD volume issue in Star Wars - Dark Forces.

### DIFF
--- a/plugins/dfsound/externals.h
+++ b/plugins/dfsound/externals.h
@@ -201,7 +201,7 @@ typedef struct
  short         * pS;
 
  void (CALLBACK *irqCallback)(void);   // func of main emu, called on spu irq
- void (CALLBACK *cddavCallback)(unsigned short,unsigned short);
+ void (CALLBACK *cddavCallback)(short, short);
  void (CALLBACK *scheduleCallback)(unsigned int);
 
  xa_decode_t   * xapGlobal;

--- a/plugins/dfsound/registers.c
+++ b/plugins/dfsound/registers.c
@@ -204,12 +204,12 @@ void CALLBACK SPUwriteRegister(unsigned long reg, unsigned short val,
       break;
     //-------------------------------------------------//
     case H_CDLeft:
-      spu.iLeftXAVol=val  & 0x7fff;
-      if(spu.cddavCallback) spu.cddavCallback(0,val);
+      spu.iLeftXAVol=(int16_t)val;
+      if(spu.cddavCallback) spu.cddavCallback(0,(int16_t)val);
       break;
     case H_CDRight:
-      spu.iRightXAVol=val & 0x7fff;
-      if(spu.cddavCallback) spu.cddavCallback(1,val);
+      spu.iRightXAVol=(int16_t)val;
+      if(spu.cddavCallback) spu.cddavCallback(1,(int16_t)val);
       break;
     //-------------------------------------------------//
     case H_FMod1:

--- a/plugins/dfsound/spu.c
+++ b/plugins/dfsound/spu.c
@@ -1580,7 +1580,7 @@ void CALLBACK SPUregisterCallback(void (CALLBACK *callback)(void))
  spu.irqCallback = callback;
 }
 
-void CALLBACK SPUregisterCDDAVolume(void (CALLBACK *CDDAVcallback)(unsigned short,unsigned short))
+void CALLBACK SPUregisterCDDAVolume(void (CALLBACK *CDDAVcallback)(short, short))
 {
  spu.cddavCallback = CDDAVcallback;
 }

--- a/plugins/spunull/spunull.c
+++ b/plugins/spunull/spunull.c
@@ -53,7 +53,7 @@ char *         pConfigFile=0;
 ////////////////////////////////////////////////////////////////////////
 
 void (CALLBACK *irqCallback)(void)=0;                   // func of main emu, called on spu irq
-void (CALLBACK *cddavCallback)(unsigned short,unsigned short)=0;
+void (CALLBACK *cddavCallback)(short, short)=0;
 
 ////////////////////////////////////////////////////////////////////////
 // CODE AREA
@@ -361,7 +361,7 @@ void CALLBACK SPUregisterCallback(void (CALLBACK *callback)(void))
  irqCallback = callback;
 }
 
-void CALLBACK SPUregisterCDDAVolume(void (CALLBACK *CDDAVcallback)(unsigned short,unsigned short))
+void CALLBACK SPUregisterCDDAVolume(void (CALLBACK *CDDAVcallback)(short, short))
 {
  cddavCallback = CDDAVcallback;
 }


### PR DESCRIPTION
Ok so here's a funny one (discovered by Mednafen once again).
CD Volume is 16-bits signed, not unsigned.

Otherwise in Star Wars Dark Forces :
If you set the volume slider to the minimum value allowed for the CD Volume, 
it will overflow and wrap around (to the maximum volume).

As far as i know, this is the only game affected by it.