### PR TITLE
Move CdlSetLoc to CdrInterrupt and return invalid arg error

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -570,6 +570,8 @@ void cdrInterrupt() {
 	int error = 0;
 	int delay;
 	unsigned int seekTime = 0;
+	u8 set_loc[3];
+	int i;
 
 	// Reschedule IRQ
 	if (cdr.Stat) {
@@ -603,6 +605,31 @@ void cdrInterrupt() {
 			break;
 
 		case CdlSetloc:
+			CDR_LOG("CDROM setloc command (%02X, %02X, %02X)\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
+
+			// MM must be BCD, SS must be BCD and <0x60, FF must be BCD and <0x75
+			if (((cdr.Param[0] & 0x0F) > 0x09) || (cdr.Param[0] > 0x99) || ((cdr.Param[1] & 0x0F) > 0x09) || (cdr.Param[1] >= 0x60) || ((cdr.Param[2] & 0x0F) > 0x09) || (cdr.Param[2] >= 0x75))
+			{
+				CDR_LOG("Invalid/out of range seek to %02X:%02X:%02X\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
+				error = ERROR_INVALIDARG;
+				goto set_error;
+			}
+			else
+			{
+				for (i = 0; i < 3; i++)
+				{
+					set_loc[i] = btoi(cdr.Param[i]);
+				}
+
+				i = msf2sec(cdr.SetSectorPlay);
+				i = abs(i - msf2sec(set_loc));
+				if (i > 16)
+					cdr.Seeked = SEEK_PENDING;
+
+				memcpy(cdr.SetSector, set_loc, 3);
+				cdr.SetSector[3] = 0;
+				cdr.SetlocPending = 1;
+			}
 			break;
 
 		do_CdlPlay:
@@ -1276,9 +1303,6 @@ unsigned char cdrRead1(void) {
 }
 
 void cdrWrite1(unsigned char rt) {
-	u8 set_loc[3];
-	int i;
-
 	CDR_LOG_IO("cdr w1: %02x\n", rt);
 
 	switch (cdr.Ctrl & 3) {
@@ -1312,31 +1336,6 @@ void cdrWrite1(unsigned char rt) {
 	AddIrqQueue(cdr.Cmd, 0x800);
 
 	switch (cdr.Cmd) {
-	case CdlSetloc:
-		CDR_LOG("CDROM setloc command (%02X, %02X, %02X)\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
-
-		// MM must be BCD, SS must be BCD and <0x60, FF must be BCD and <0x75
-		if (((cdr.Param[0] & 0x0F) > 0x09) || (cdr.Param[0] > 0x99) || ((cdr.Param[1] & 0x0F) > 0x09) || (cdr.Param[1] >= 0x60) || ((cdr.Param[2] & 0x0F) > 0x09) || (cdr.Param[2] >= 0x75))
-		{
-			CDR_LOG("Invalid/out of range seek to %02X:%02X:%02X\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
-		}
-		else
-		{
-			for (i = 0; i < 3; i++)
-			{
-				set_loc[i] = btoi(cdr.Param[i]);
-			}
-
-			i = msf2sec(cdr.SetSectorPlay);
-			i = abs(i - msf2sec(set_loc));
-			if (i > 16)
-				cdr.Seeked = SEEK_PENDING;
-
-			memcpy(cdr.SetSector, set_loc, 3);
-			cdr.SetSector[3] = 0;
-			cdr.SetlocPending = 1;
-		}
-		break;
 
 	case CdlReadN:
 	case CdlReadS:


### PR DESCRIPTION
So far,
i could only find Simple 1500 Series Vol. 31 - The Sound Novel to be affected by this.
In Duckstation, this was causing extra delays without it.
However in our case, this doesn't seem to be the case and i couldn't find much find about it.

I moved it to cdrInterrupt as there was no error handling in cdrWrite1
and we are supposed to return "Invalid arg" upon the check being met.
https://github.com/stenzek/duckstation/commit/c962e9899d75e95646bedd1d03e3052e634ec92f#diff-0077a49e8c9a58eb9c85becc595ff6cf27e560f1728116423a5aaa52b8b30e89

I don't think i'm doing anything wrong but let me know, it's kind of iffy.