### PR TITLE
Remove CdlGetlocP hack.

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -814,9 +814,6 @@ void cdrInterrupt() {
 		case CdlGetlocP:
 			SetResultSize(8);
 			memcpy(&cdr.Result, &cdr.subq, 8);
-
-			if (!cdr.Play && !cdr.Reading)
-				cdr.Result[1] = 0; // HACK?
 			break;
 
 		case CdlReadT: // SetSession?


### PR DESCRIPTION
This was added back in 2013 or so in PCSX Rearmed
and according to some tests against Tomb Raider 1 (which is affected by the GetLocP code),
it works properly without this hack.

So let's just remove it as we are now doing it properly. (Besides, Duckstation and mednafen don't have this hack)
https://github.com/libretro-mirrors/mednafen-git/blob/master/src/psx/cdc.cpp#L2133