### PR TITLE
clear Index0 data FIFO flag

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -1281,8 +1281,8 @@ unsigned char cdrRead0(void) {
 
 	if (cdr.OCUP)
 		cdr.Ctrl |= 0x40;
-//  else
-//		cdr.Ctrl &= ~0x40;
+	else
+		cdr.Ctrl &= ~0x40;
 
 	// What means the 0x10 and the 0x08 bits? I only saw it used by the bios
 	cdr.Ctrl |= 0x18;
@@ -1378,6 +1378,7 @@ unsigned char cdrRead2(void) {
 	unsigned char ret;
 
 	if (cdr.Readed == 0) {
+		cdr.OCUP = 0;
 		ret = 0;
 	} else {
 		ret = *pTransfer++;


### PR DESCRIPTION
Merge PCSX Redux fix.
It can be found here : https://github.com/johnbaumann/pcsx-redux/commit/9ab09443ff44f0429185881bb89309f5aea36eb0

This is what he had to say about it :
"So, this commit works around/fixes two issues with loading unirom.
There's a fix for logging invalid commands which should be pretty straight forward. The other change is around the FIFO flag.
Not really experienced with debugging/verifying this sort of thing so not feeling really confident the change is "right", though every game I've tried so far still seem to work as expected.
There's still something going on with not having an iso mounted that I haven't quite nailed down. Even having the iso mounted with "lid open" gives a bootable result. Feel like I'm going in circles a bit for something that might be an easy fix. Unirom is technically usable via ISO, but the unirom exe freezes if no iso is loaded"