### PR TITLE
Fix silly typo mistake for CDROM pause/resume fix for DOA.

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -775,7 +775,7 @@ void cdrInterrupt() {
 			 * Mednafen's timing don't work for Gundam Battle Assault 2 in PAL/50hz mode,
 			 * seems to be timing sensitive as it can depend on the CPU's clock speed.
 			 * */
-			if (cdr.DriveState != DRIVESTATE_STANDBY)
+			if (cdr.DriveState == DRIVESTATE_STANDBY)
 			{
 				delay = 7000;
 			}


### PR DESCRIPTION
My bad guys.

Thanks to https://github.com/CometHunter92/pcsx_rearmed/commit/242b473df8b88101a013b639604b06d4418fad47 for noticing the issue, i had correctly fixed this in my PR for redux but not this one.