### PR TITLE
Fix building gpu_unai on armv6

### DIFF
--- a/plugins/gpu_unai/gpulib_if.cpp
+++ b/plugins/gpu_unai/gpulib_if.cpp
@@ -173,7 +173,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
 
   linesInterlace = force_interlace;
 #ifdef HAVE_PRE_ARMV7 /* XXX */
-  linesInterlace |= gpu.status.interlace;
+  linesInterlace |= !!(gpu.status & PSX_GPU_STATUS_INTERLACE);
 #endif
 
   for (; list < list_end; list += 1 + len)


### PR DESCRIPTION
f23b103c8248c10855949bfb2185b6b10d4f0457 was missing changes to gpu_unai/gpulib_if.cpp