### PR TITLE
dfsound: Fix issues on big-endian systems

### DIFF
--- a/plugins/dfsound/registers.c
+++ b/plugins/dfsound/registers.c
@@ -22,6 +22,7 @@
 #include "externals.h"
 #include "registers.h"
 #include "spu_config.h"
+#include "spu.h"
 
 static void SoundOn(int start,int end,unsigned short val);
 static void SoundOff(int start,int end,unsigned short val);
@@ -127,7 +128,7 @@ void CALLBACK SPUwriteRegister(unsigned long reg, unsigned short val,
       break;
     //-------------------------------------------------//
     case H_SPUdata:
-      *(unsigned short *)(spu.spuMemC + spu.spuAddr) = val;
+      *(unsigned short *)(spu.spuMemC + spu.spuAddr) = HTOLE16(val);
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       break;
@@ -334,7 +335,7 @@ unsigned short CALLBACK SPUreadRegister(unsigned long reg)
 
     case H_SPUdata:
      {
-      unsigned short s = *(unsigned short *)(spu.spuMemC + spu.spuAddr);
+      unsigned short s = LE16TOH(*(unsigned short *)(spu.spuMemC + spu.spuAddr));
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       return s;

--- a/plugins/dfsound/reverb.c
+++ b/plugins/dfsound/reverb.c
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include "stdafx.h"
+#include "spu.h"
 
 #define _IN_REVERB
 
@@ -50,16 +51,16 @@ INLINE int rvb2ram_offs(int curr, int space, int iOff)
 
 // get_buffer content helper: takes care about wraps
 #define g_buffer(var) \
- ((int)(signed short)spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)])
+ ((int)(signed short)LE16TOH(spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)]))
 
 // saturate iVal and store it as var
 #define s_buffer(var, iVal) \
  ssat32_to_16(iVal); \
- spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)] = iVal
+ spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var)] = HTOLE16(iVal)
 
 #define s_buffer1(var, iVal) \
  ssat32_to_16(iVal); \
- spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var + 1)] = iVal
+ spu.spuMem[rvb2ram_offs(curr_addr, space, rvb->var + 1)] = HTOLE16(iVal)
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/plugins/dfsound/spu.h
+++ b/plugins/dfsound/spu.h
@@ -18,6 +18,14 @@
 #ifndef __P_SPU_H__
 #define __P_SPU_H__
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define HTOLE16(x) __builtin_bswap16(x)
+#define LE16TOH(x) __builtin_bswap16(x)
+#else
+#define HTOLE16(x) (x)
+#define LE16TOH(x) (x)
+#endif
+
 void ClearWorkingState(void);
 void CALLBACK SPUplayADPCMchannel(xa_decode_t *xap, unsigned int cycle, int is_start);
 int  CALLBACK SPUplayCDDAchannel(short *pcm, int bytes, unsigned int cycle, int is_start);

--- a/plugins/dfsound/xa.c
+++ b/plugins/dfsound/xa.c
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "stdafx.h"
+#include "spu.h"
 #define _IN_XA
 #include <stdint.h>
 
@@ -60,8 +61,8 @@ INLINE void MixXA(int *SSumLR, int ns_to, int decode_pos)
     SSumLR[ns++] += l;
     SSumLR[ns++] += r;
 
-    spu.spuMem[cursor] = v;
-    spu.spuMem[cursor + 0x400/2] = v >> 16;
+    spu.spuMem[cursor] = HTOLE16(v);
+    spu.spuMem[cursor + 0x400/2] = HTOLE16(v >> 16);
     cursor = (cursor + 1) & 0x1ff;
    }
   spu.XALastVal = v;
@@ -80,8 +81,8 @@ INLINE void MixXA(int *SSumLR, int ns_to, int decode_pos)
     SSumLR[ns++] += l;
     SSumLR[ns++] += r;
 
-    spu.spuMem[cursor] = v;
-    spu.spuMem[cursor + 0x400/2] = v >> 16;
+    spu.spuMem[cursor] = HTOLE16(v);
+    spu.spuMem[cursor + 0x400/2] = HTOLE16(v >> 16);
     cursor = (cursor + 1) & 0x1ff;
    }
   spu.XALastVal = v;


### PR DESCRIPTION
Without this fix, the BIOS' music is missing on big-endian systems.

Original fix by @xjsxjs197.