### PR TITLE
add Bomberman: Fantasy Race to database for hack "(GPU) slow linked list walking"

### DIFF
--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -20,6 +20,8 @@ static const char * const cdr_read_hack_db[] =
 
 static const char * const gpu_slow_llist_db[] =
 {
+	/* Bomberman Fantasy Race */
+	"SLES01712", "SLPS01525", "SLPS91138", "SLPM87102", "SLUS00823",
 	/* Crash Bash */
 	"SCES02834", "SCUS94570", "SCUS94616", "SCUS94654",
 	/* Final Fantasy IV */


### PR DESCRIPTION
Without it, the Retry/Quit menu when you lose a race is invisible.

Fixes https://github.com/libretro/pcsx_rearmed/issues/776.