### PR TITLE
more timing hacks: fix jump command on Power Rangers - Lightspeed Rescue

### DIFF
--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -120,6 +120,8 @@ cycle_multiplier_overrides[] =
 	{ 222, { "SLES01549", "SLES02063", "SLES02064" } },
 	/* Digimon World */
 	{ 153, { "SLUS01032", "SLES02914" } },
+	/* Power Rangers: Lightspeed Rescue - jump does not work with 175 */
+	{ 222, { "SLUS01114", "SLES03286" } },
 	/* Syphon Filter - reportedly hangs under unknown conditions */
 	{ 169, { "SCUS94240" } },
 	/* Psychic Detective - some weird race condition in the game's cdrom code */


### PR DESCRIPTION
Fixes issue https://github.com/libretro/pcsx_rearmed/issues/837