### PR TITLE
Update timing (override) hack for Power Rangers: Lightspeed Rescue (SuperrSonic)

### DIFF
--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -121,7 +121,7 @@ cycle_multiplier_overrides[] =
 	/* Digimon World */
 	{ 153, { "SLUS01032", "SLES02914" } },
 	/* Power Rangers: Lightspeed Rescue - jump does not work with 175 */
-	{ 222, { "SLUS01114", "SLES03286" } },
+	{ 310, { "SLUS01114", "SLES03286" } },
 	/* Syphon Filter - reportedly hangs under unknown conditions */
 	{ 169, { "SCUS94240" } },
 	/* Psychic Detective - some weird race condition in the game's cdrom code */

--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -120,7 +120,7 @@ cycle_multiplier_overrides[] =
 	{ 222, { "SLES01549", "SLES02063", "SLES02064" } },
 	/* Digimon World */
 	{ 153, { "SLUS01032", "SLES02914" } },
-	/* Power Rangers: Lightspeed Rescue - jump does not work with 175 */
+	/* Power Rangers: Lightspeed Rescue - jumping fails if FPS is over 30 */
 	{ 310, { "SLUS01114", "SLES03286" } },
 	/* Syphon Filter - reportedly hangs under unknown conditions */
 	{ 169, { "SCUS94240" } },


### PR DESCRIPTION
According to SuperrSonic, the game's jumping command does not work if the game FPS is over 30.

At 280, on level 3 has audio stutters. Needs more testing.

SuperrSonic found 310 ideal to maintain the emulation at full speed, at the cost of the game dropping more frames, this allowed jumping to always work and keep the sound stutter free, as it was tested the entire game this way.

Credit to @SuperrSonic for this fix.

Read this message for further info: https://github.com/libretro/pcsx_rearmed/issues/837#issuecomment-2189745153