### PR TITLE
frontend/menu: update (C) year

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -1,5 +1,5 @@
 /*
- * (C) notaz, 2010-2012
+ * (C) notaz, 2010-2025
  *
  * This work is licensed under the terms of the GNU GPLv2 or later.
  * See the COPYING file in the top-level directory.

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2071,7 +2071,7 @@ static const char credits_text[] =
 	"PCSX4ALL plugin by PCSX4ALL team\n"
 	"  Chui, Franxis, Unai\n\n"
 	"integration, optimization and\n"
-	"  frontend (C) 2010-2015 notaz\n";
+	"  frontend (C) 2010-2025 notaz\n";
 
 static int reset_game(void)
 {


### PR DESCRIPTION
just an excuse to ask if you could git tag r24 & r25 release? Otherwise the OSD indicates it still on r23 when defining VER with `git describe --always`, also it's easier to fetch tarballs for CI this way