### PR TITLE
configure: unset `PIC` cflag for plugins if not used

### DIFF
--- a/configure
+++ b/configure
@@ -355,6 +355,8 @@ fi
 # supposedly we can avoid -fPIC on armv5 for slightly better performace?
 if [ "$ARCH" != "arm" -o "$have_armv6" = "yes" ]; then
   PLUGIN_CFLAGS="$PLUGIN_CFLAGS -fPIC"
+else
+  PLUGIN_CFLAGS="$PLUGIN_CFLAGS -fno-PIC"
 fi
 
 case "$platform" in

--- a/plugins/gpu-gles/Makefile
+++ b/plugins/gpu-gles/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -ggdb -fPIC -O2 # -Wall
+CFLAGS += -ggdb -O2 # -Wall
 
 include ../../config.mak
 

--- a/plugins/spunull/Makefile
+++ b/plugins/spunull/Makefile
@@ -6,8 +6,10 @@ PLUGINDIR = $(shell basename $(WD))
 
 all: ../../config.mak $(TARGET)
 
+CFLAGS += $(PLUGIN_CFLAGS)
+
 $(TARGET): spunull.c
-	$(CC) $(CFLAGS) -shared -fPIC -ggdb -O2 -o $@ $^
+	$(CC) $(CFLAGS) -shared -ggdb -O2 -o $@ $^
 	ln -fs $(PLUGINDIR)/$(TARGET) ../
 
 clean:


### PR DESCRIPTION
also don't redefine PIC in Makefiles

I've had `reloc type` error, when used with gcc compiled with -fPIE as def cflag otherwise on armv5