### PR TITLE
plugins: fix missing func. calls in laodGPUplugin()

### DIFF
--- a/libpcsxcore/plugins.c
+++ b/libpcsxcore/plugins.c
@@ -207,12 +207,12 @@ static int LoadGPUplugin(const char *GPUdll) {
 	LoadGpuSym1(writeStatus, "GPUwriteStatus");
 	LoadGpuSym1(dmaChain, "GPUdmaChain");
 	LoadGpuSym1(updateLace, "GPUupdateLace");
-	LoadGpuSym0(keypressed, "GPUkeypressed");
-	LoadGpuSym0(displayText, "GPUdisplayText");
-	LoadGpuSym0(makeSnapshot, "GPUmakeSnapshot");
+	// LoadGpuSym0(keypressed, "GPUkeypressed");
+	// LoadGpuSym0(displayText, "GPUdisplayText");
+	// LoadGpuSym0(makeSnapshot, "GPUmakeSnapshot");
 	LoadGpuSym1(freeze, "GPUfreeze");
 	LoadGpuSym0(getScreenPic, "GPUgetScreenPic");
-	LoadGpuSym0(showScreenPic, "GPUshowScreenPic");
+	// LoadGpuSym0(showScreenPic, "GPUshowScreenPic");
 	LoadGpuSym0(vBlank, "GPUvBlank");
 	LoadGpuSym0(getScreenInfo, "GPUgetScreenInfo");
 

--- a/plugins/gpulib/gpu.c
+++ b/plugins/gpulib/gpu.c
@@ -307,6 +307,11 @@ long GPUshutdown(void)
   return ret;
 }
 
+long GPUgetScreenPic(unsigned char * pMem)
+{
+  return 0;
+}
+
 void GPUwriteStatus(uint32_t data)
 {
   uint32_t cmd = data >> 24;

--- a/plugins/gpulib/gpu.h
+++ b/plugins/gpulib/gpu.h
@@ -168,6 +168,7 @@ long GPUfreeze(uint32_t type, struct GPUFreeze *freeze);
 void GPUupdateLace(void);
 long GPUopen(unsigned long *disp, char *cap, char *cfg);
 long GPUclose(void);
+long GPUgetScreenPic(unsigned char *);
 void GPUvBlank(int is_vblank, int lcf);
 void GPUgetScreenInfo(int *y, int *base_hres);
 void GPUrearmedCallbacks(const struct rearmed_cbs *cbs_);


### PR DESCRIPTION
- add missing GPUgetScreenPic
- remove obsolete ones (as far as I can see)

couldn't run in any of my setup otherwise when using shared GPU plugins (was easier to bisect on musl).