### PR TITLE
frontend/menu: omit already build-in GPU in external plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ CFLAGS += -DGPU_PEOPS
 # note: code is not safe for strict-aliasing? (Castlevania problems)
 plugins/dfxvideo/gpulib_if.o: CFLAGS += -fno-strict-aliasing
 plugins/dfxvideo/gpulib_if.o: plugins/dfxvideo/prim.c plugins/dfxvideo/soft.c
+frontend/menu.o frontend/plugin_lib.o: CFLAGS += -DBUILTIN_GPU_PEOPS
 OBJS += plugins/dfxvideo/gpulib_if.o
 ifeq "$(THREAD_RENDERING)" "1"
 CFLAGS += -DTHREAD_RENDERING
@@ -295,6 +296,7 @@ CFLAGS += -DGPU_UNAI_NO_OLD
 endif
 plugins/gpu_unai/gpulib_if.o: plugins/gpu_unai/*.h
 plugins/gpu_unai/gpulib_if.o: CFLAGS += -DREARMED -DUSE_GPULIB=1
+frontend/menu.o frontend/plugin_lib.o: CFLAGS += -DBUILTIN_GPU_UNAI
 ifneq ($(DEBUG), 1)
 plugins/gpu_unai/gpulib_if.o \
 plugins/gpu_unai/old/if.o: CFLAGS += -O3

--- a/configure
+++ b/configure
@@ -44,8 +44,7 @@ dynarec_list="ari64 lightrec none"
 builtin_gpu=""
 sound_driver_list="oss alsa pulseaudio sdl"
 sound_drivers=""
-plugins="plugins/spunull/spunull.so \
-plugins/dfxvideo/gpu_peops.so plugins/gpu_unai/gpu_unai.so"
+plugins=""
 drc_cache_base="no"
 have_armv5=""
 have_armv6=""
@@ -549,6 +548,15 @@ if check_c64_tools; then
   have_c64x_dsp="yes"
 fi
 
+# declare available dynamic plugins
+plugins="plugins/spunull/spunull.so"
+
+if [ "$builtin_gpu" != "peops" ]; then
+plugins="$plugins plugins/dfxvideo/gpu_peops.so"
+fi
+if [ "$builtin_gpu" != "unai" ]; then
+plugins="$plugins plugins/gpu_unai/gpu_unai.so"
+fi
 if [ "$have_gles" = "yes" ]; then
   plugins="$plugins plugins/gpu-gles/gpu_gles.so"
 fi

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1556,8 +1556,12 @@ static const char h_bios[]       = "HLE is simulated BIOS. BIOS selection is sav
 				   "savestates and can't be changed there. Must save\n"
 				   "config and reload the game for change to take effect";
 static const char h_plugin_gpu[] = 
-#ifdef BUILTIN_GPU_NEON
+#if defined(BUILTIN_GPU_NEON)
 				   "builtin_gpu is the NEON GPU, very fast and accurate\n"
+#elif defined(BUILTIN_GPU_PEOPS)
+				   "builtin_gpu is the P.E.Op.S GPU, slow but accurate\n"
+#elif defined(BUILTIN_GPU_UNAI)
+				   "builtin_gpu is the Unai GPU, very fast\n"
 #endif
 				   "gpu_peops is Pete's soft GPU, slow but accurate\n"
 				   "gpu_unai is the GPU renderer from PCSX4ALL\n"
@@ -1576,8 +1580,12 @@ static menu_entry e_menu_plugin_options[] =
 	mee_enum      ("GPU Dithering",                 0, pl_rearmed_cbs.dithering, men_gpu_dithering),
 	mee_enum_h    ("GPU plugin",                    0, gpu_plugsel, gpu_plugins, h_plugin_gpu),
 	mee_enum_h    ("SPU plugin",                    0, spu_plugsel, spu_plugins, h_plugin_spu),
-#ifdef BUILTIN_GPU_NEON
+#if defined(BUILTIN_GPU_NEON)
 	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_neon, h_gpu_neon),
+#elif defined(BUILTIN_GPU_PEOPS)
+	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_peops, h_gpu_peops),
+#elif defined(BUILTIN_GPU_UNAI)
+	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_unai, h_gpu_unai),
 #endif
 	mee_handler_h ("Configure gpu_peops plugin",    menu_loop_plugin_gpu_peops, h_gpu_peops),
 	mee_handler_h ("Configure gpu_unai GPU plugin", menu_loop_plugin_gpu_unai, h_gpu_unai),


### PR DESCRIPTION
also don't build shared object for built-in one