### PR TITLE
frontend/menu: only display sel. GPU plug setting

### DIFF
--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1411,8 +1411,6 @@ static int menu_loop_gfx_options(int id, int keys)
 
 // ------------ bios/plugins ------------
 
-#ifdef BUILTIN_GPU_NEON
-
 static const char h_gpu_neon[] =
 	"Configure built-in NEON GPU plugin";
 static const char h_gpu_neon_enhanced[] =
@@ -1439,8 +1437,6 @@ static int menu_loop_plugin_gpu_neon(int id, int keys)
 	me_loop(e_menu_plugin_gpu_neon, &sel);
 	return 0;
 }
-
-#endif
 
 static menu_entry e_menu_plugin_gpu_unai[] =
 {
@@ -2077,9 +2073,7 @@ static const char credits_text[] =
 	"(C) 2005-2009 PCSX-df Team\n"
 	"(C) 2009-2011 PCSX-Reloaded Team\n\n"
 	"ARM recompiler (C) 2009-2011 Ari64\n"
-#ifdef BUILTIN_GPU_NEON
 	"ARM NEON GPU (c) 2011-2012 Exophase\n"
-#endif
 	"PEOpS GPU and SPU by Pete Bernert\n"
 	"  and the P.E.Op.S. team\n"
 	"PCSX4ALL plugin by PCSX4ALL team\n"

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1411,8 +1411,6 @@ static int menu_loop_gfx_options(int id, int keys)
 
 // ------------ bios/plugins ------------
 
-static const char h_gpu_neon[] =
-	"Configure built-in NEON GPU plugin";
 static const char h_gpu_neon_enhanced[] =
 	"Renders in double resolution at perf. cost\n"
 	"(not available for high resolution games)";
@@ -1431,13 +1429,6 @@ static menu_entry e_menu_plugin_gpu_neon[] =
 	mee_end,
 };
 
-static int menu_loop_plugin_gpu_neon(int id, int keys)
-{
-	static int sel = 0;
-	me_loop(e_menu_plugin_gpu_neon, &sel);
-	return 0;
-}
-
 static menu_entry e_menu_plugin_gpu_unai[] =
 {
 	mee_onoff     ("Old renderer",               0, pl_rearmed_cbs.gpu_unai.old_renderer, 1),
@@ -1447,14 +1438,6 @@ static menu_entry e_menu_plugin_gpu_unai[] =
 	mee_onoff     ("Blending",                   0, pl_rearmed_cbs.gpu_unai.blending, 1),
 	mee_end,
 };
-
-static int menu_loop_plugin_gpu_unai(int id, int keys)
-{
-	int sel = 0;
-	me_loop(e_menu_plugin_gpu_unai, &sel);
-	return 0;
-}
-
 
 //static const char h_gpu_0[]            = "Needed for Chrono Cross";
 static const char h_gpu_1[]            = "Capcom fighting games";
@@ -1479,13 +1462,6 @@ static menu_entry e_menu_plugin_gpu_peops[] =
 	mee_onoff_h   ("Fake 'gpu busy' states",     0, pl_rearmed_cbs.gpu_peops.dwActFixes, 1<<10, h_gpu_10),
 	mee_end,
 };
-
-static int menu_loop_plugin_gpu_peops(int id, int keys)
-{
-	static int sel = 0;
-	me_loop(e_menu_plugin_gpu_peops, &sel);
-	return 0;
-}
 
 static const char *men_peopsgl_texfilter[] = { "None", "Standard", "Extended",
 	"Standard-sprites", "Extended-sprites", "Standard+sprites", "Extended+sprites", NULL };
@@ -1558,9 +1534,9 @@ static const char h_plugin_gpu[] =
 				   "must save config and reload the game if changed";
 static const char h_plugin_spu[] = "spunull effectively disables sound\n"
 				   "must save config and reload the game if changed";
-static const char h_gpu_peops[]  = "Configure P.E.Op.S. SoftGL Driver V1.17";
-static const char h_gpu_peopsgl[]= "Configure P.E.Op.S. MesaGL Driver V1.78";
-static const char h_gpu_unai[]   = "Configure Unai/PCSX4ALL Team plugin (new)";
+// static const char h_gpu_peops[]  = "Configure P.E.Op.S. SoftGL Driver V1.17";
+// static const char h_gpu_peopsgl[]= "Configure P.E.Op.S. MesaGL Driver V1.78";
+// static const char h_gpu_unai[]   = "Configure Unai/PCSX4ALL Team plugin (new)";
 static const char h_spu[]        = "Configure built-in P.E.Op.S. Sound Driver V1.7";
 
 static int menu_loop_pluginsel_options(int id, int keys)

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1521,13 +1521,6 @@ static menu_entry e_menu_plugin_gpu_peopsgl[] =
 	mee_end,
 };
 
-static int menu_loop_plugin_gpu_peopsgl(int id, int keys)
-{
-	static int sel = 0;
-	me_loop(e_menu_plugin_gpu_peopsgl, &sel);
-	return 0;
-}
-
 static const char *men_spu_interp[] = { "None", "Simple", "Gaussian", "Cubic", NULL };
 static const char h_spu_volboost[]  = "Large values cause distortion";
 static const char h_spu_tempo[]     = "Slows down audio if emu is too slow\n"
@@ -1574,22 +1567,35 @@ static const char h_gpu_peopsgl[]= "Configure P.E.Op.S. MesaGL Driver V1.78";
 static const char h_gpu_unai[]   = "Configure Unai/PCSX4ALL Team plugin (new)";
 static const char h_spu[]        = "Configure built-in P.E.Op.S. Sound Driver V1.7";
 
+static int menu_loop_pluginsel_options(int id, int keys)
+{
+	static int sel = 0;
+	if (strcmp(gpu_plugins[gpu_plugsel], "gpu_peops.so") == 0)
+		me_loop(e_menu_plugin_gpu_peops, &sel);
+	else if (strcmp(gpu_plugins[gpu_plugsel], "gpu_unai.so") == 0)
+		me_loop(e_menu_plugin_gpu_unai, &sel);
+	else if (strcmp(gpu_plugins[gpu_plugsel], "gpu_gles.so") == 0)
+		me_loop(e_menu_plugin_gpu_peopsgl, &sel);
+	else if (strcmp(gpu_plugins[gpu_plugsel], "gpu_neon.so") == 0)
+		me_loop(e_menu_plugin_gpu_neon, &sel);
+	else
+#if defined(BUILTIN_GPU_NEON)
+		me_loop(e_menu_plugin_gpu_neon, &sel);
+#elif defined(BUILTIN_GPU_PEOPS)
+		me_loop(e_menu_plugin_gpu_peops, &sel);
+#elif defined(BUILTIN_GPU_UNAI)
+		me_loop(e_menu_plugin_gpu_unai, &sel);
+#endif
+	return 0;
+}
+
 static menu_entry e_menu_plugin_options[] =
 {
 	mee_enum_h    ("BIOS",                          0, bios_sel, bioses, h_bios),
 	mee_enum      ("GPU Dithering",                 0, pl_rearmed_cbs.dithering, men_gpu_dithering),
 	mee_enum_h    ("GPU plugin",                    0, gpu_plugsel, gpu_plugins, h_plugin_gpu),
 	mee_enum_h    ("SPU plugin",                    0, spu_plugsel, spu_plugins, h_plugin_spu),
-#if defined(BUILTIN_GPU_NEON)
-	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_neon, h_gpu_neon),
-#elif defined(BUILTIN_GPU_PEOPS)
-	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_peops, h_gpu_peops),
-#elif defined(BUILTIN_GPU_UNAI)
-	mee_handler_h ("Configure built-in GPU plugin", menu_loop_plugin_gpu_unai, h_gpu_unai),
-#endif
-	mee_handler_h ("Configure gpu_peops plugin",    menu_loop_plugin_gpu_peops, h_gpu_peops),
-	mee_handler_h ("Configure gpu_unai GPU plugin", menu_loop_plugin_gpu_unai, h_gpu_unai),
-	mee_handler_h ("Configure gpu_gles GPU plugin", menu_loop_plugin_gpu_peopsgl, h_gpu_peopsgl),
+	mee_handler   ("Configure selected GPU plugin", menu_loop_pluginsel_options),
 	mee_handler_h ("Configure built-in SPU plugin", menu_loop_plugin_spu, h_spu),
 	mee_end,
 };

--- a/frontend/plugin_lib.c
+++ b/frontend/plugin_lib.c
@@ -519,7 +519,6 @@ static int dispmode_default(void)
 	return 1;
 }
 
-#ifdef BUILTIN_GPU_NEON
 static int dispmode_doubleres(void)
 {
 	if (!(pl_rearmed_cbs.gpu_caps & GPU_CAP_SUPPORTS_2X)
@@ -531,7 +530,6 @@ static int dispmode_doubleres(void)
 	snprintf(hud_msg, sizeof(hud_msg), "double resolution");
 	return 1;
 }
-#endif
 
 #ifdef HAVE_NEON32
 static int dispmode_scale2x(void)
@@ -559,9 +557,7 @@ static int dispmode_eagle2x(void)
 
 static int (*dispmode_switchers[])(void) = {
 	dispmode_default,
-#ifdef BUILTIN_GPU_NEON
 	dispmode_doubleres,
-#endif
 #ifdef HAVE_NEON32
 	dispmode_scale2x,
 	dispmode_eagle2x,

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ GPU (graphics) and SPU (sound) plugins can be selected in
 builtin_gpu    - this is either Exophase's ARM NEON GPU (accurate and fast,
                  available if platform supports NEON, like on pandora),
                  gpu_peops or gpu_unai (depends on compile options).
+gpu_neon.so    - Exophase's ARM NEON GPU with ARMv7 assembly optimizations.
 gpu_peops.so   - P.E.Op.S. soft GPU, reasonably accurate but slow
                  (also found with older emulators on PC)
 gpu_gles.so    - experimental port of P.E.Op.S. MesaGL plugin to OpenGL ES.


### PR DESCRIPTION
I'm trying to make [BIOS/Plugins] sub-menu less overwhelming

the `menu_loop_plugin_gpu_peopsgl` becomes obsolete now but the rest of gpu loops will be legit after: https://github.com/notaz/pcsx_rearmed/pull/365

P.S. Moreover I tried to update gpu descrip. header dynamicly, but it will only work when moving "Configure external GPU" menu entry to another sub-menu, so better to leave it as it is.