### PR TITLE
frontend/menu: display descrip. only for supported GPU plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ rel: pcsx $(PLUGINS) \
 	mkdir -p $(OUT)/plugins
 	mkdir -p $(OUT)/bios
 	cp -r $^ $(OUT)/
-	mv $(OUT)/*.so* $(OUT)/plugins/
+	-mv $(OUT)/*.so* $(OUT)/plugins/
 	zip -9 -r $(OUT).zip $(OUT)
 endif
 
@@ -569,7 +569,7 @@ rel: pcsx plugins/dfsound/pcsxr_spu_area3.out $(PLUGINS) \
 	cp -r $^ out/
 	sed -e 's/%PR%/$(VER)/g' out/pcsx.pxml.templ > out/pcsx.pxml
 	rm out/pcsx.pxml.templ
-	mv out/*.so out/plugins/
+	-mv out/*.so out/plugins/
 	$(PND_MAKE) -p pcsx_rearmed_$(VER).pnd -d out -x out/pcsx.pxml -i frontend/pandora/pcsx.png -c
 endif
 
@@ -589,7 +589,7 @@ rel: pcsx $(PLUGINS) \
 	rm -rf out
 	mkdir -p out/pcsx_rearmed/plugins
 	cp -r $^ out/pcsx_rearmed/
-	mv out/pcsx_rearmed/*.so out/pcsx_rearmed/plugins/
+	-mv out/pcsx_rearmed/*.so out/pcsx_rearmed/plugins/
 	mv out/pcsx_rearmed/caanoo.gpe out/pcsx_rearmed/pcsx.gpe
 	mv out/pcsx_rearmed/pcsx_rearmed.ini out/
 	mkdir out/pcsx_rearmed/lib/

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,14 @@ ifneq ($(findstring libretro,$(SOUND_DRIVERS)),)
 plugins/dfsound/out.o: CFLAGS += -DHAVE_LIBRETRO
 endif
 
+# supported gpu list in menu
+ifeq "$(HAVE_NEON_GPU)" "1"
+frontend/menu.o: CFLAGS += -DGPU_NEON
+endif
+ifeq "$(HAVE_GLES)" "1"
+frontend/menu.o: CFLAGS += -DHAVE_GLES
+endif
+
 # builtin gpu
 OBJS += plugins/gpulib/gpu.o plugins/gpulib/vout_pl.o plugins/gpulib/prim.o
 ifeq "$(BUILTIN_GPU)" "neon"

--- a/configure
+++ b/configure
@@ -57,6 +57,7 @@ have_evdev=""
 have_gles=""
 have_c64x_dsp=""
 have_fsections="yes"
+have_dynamic="yes"
 gnu_linker="yes"
 dynarec=""
 multithreading="yes"
@@ -170,6 +171,10 @@ for opt do
   ;;
   --disable-threads) multithreading="no"
   ;;
+  --enable-dynamic) have_dynamic="yes"
+  ;;
+  --disable-dynamic) have_dynamic="no"
+  ;;
   --dynarec=*) dynarec="$optarg"
   ;;
   --disable-dynarec) dynarec="no"
@@ -192,6 +197,8 @@ if [ "$show_help" = "yes" ]; then
   echo "  --disable-neon           enable/disable ARM NEON optimizations [guessed]"
   echo "  --enable-threads"
   echo "  --disable-threads        enable/disable multithreaded features [guessed]"
+  echo "  --enable-dynamic"
+  echo "  --disable-dynamic        enable/disable dynamic loading obj. eg.plugins [guessed]"
   echo "  --dynarec=NAME           select dynamic recompiler [guessed]"
   echo "                           available: $dynarec_list"
   echo "influential environment variables:"
@@ -547,19 +554,24 @@ if check_c64_tools; then
 fi
 
 # declare available dynamic plugins
-plugins="plugins/spunull/spunull.so"
+if [ "$have_dynamic" = "yes" ]; then
+  plugins="plugins/spunull/spunull.so"
 
-if [ "$builtin_gpu" != "peops" ]; then
-  plugins="$plugins plugins/dfxvideo/gpu_peops.so"
-fi
-if [ "$builtin_gpu" != "unai" ]; then
-  plugins="$plugins plugins/gpu_unai/gpu_unai.so"
-fi
-if [ "$have_gles" = "yes" ]; then
-  plugins="$plugins plugins/gpu-gles/gpu_gles.so"
-fi
-if [ "$have_neon_gpu" = "yes" -a "$builtin_gpu" != "neon" ]; then
-  plugins="$plugins plugins/gpu_neon/gpu_neon.so"
+  if [ "$builtin_gpu" != "peops" ]; then
+    plugins="$plugins plugins/dfxvideo/gpu_peops.so"
+  fi
+  if [ "$builtin_gpu" != "unai" ]; then
+    plugins="$plugins plugins/gpu_unai/gpu_unai.so"
+  fi
+  if [ "$have_gles" = "yes" ]; then
+    plugins="$plugins plugins/gpu-gles/gpu_gles.so"
+  fi
+  if [ "$have_neon_gpu" = "yes" -a "$builtin_gpu" != "neon" ]; then
+    plugins="$plugins plugins/gpu_neon/gpu_neon.so"
+  fi
+else
+  have_dynamic="no"
+  CFLAGS="$CFLAGS -DNO_DYLIB"
 fi
 
 # check for xlib (only headers needed)

--- a/configure
+++ b/configure
@@ -637,6 +637,9 @@ echo "PLATFORM = $platform" >> $config_mak
 echo "BUILTIN_GPU = $builtin_gpu" >> $config_mak
 echo "SOUND_DRIVERS = $sound_drivers" >> $config_mak
 echo "PLUGINS = $plugins" >> $config_mak
+if [ "$have_neon_gpu" = "yes" ]; then
+  echo "HAVE_NEON_GPU = 1" >> $config_mak
+fi
 if [ "$have_arm_neon" = "yes" ]; then
   echo "HAVE_NEON = 1" >> $config_mak
 fi

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1528,6 +1528,7 @@ static const char h_plugin_gpu[] =
 #elif defined(BUILTIN_GPU_UNAI)
 				   "builtin_gpu is the Unai GPU, very fast\n"
 #endif
+#ifndef NO_DYLIB
 #if !defined(BUILTIN_GPU_NEON) && defined(GPU_NEON)
 				   "gpu_neon is Exophase's NEON GPU, fast and accurate\n"
 #endif
@@ -1540,9 +1541,15 @@ static const char h_plugin_gpu[] =
 #ifdef HAVE_GLES
 				   "gpu_gles Pete's hw GPU, uses 3D chip but is glitchy\n"
 #endif
-				   "must save config and reload the game if changed";
-static const char h_plugin_spu[] = "spunull effectively disables sound\n"
-				   "must save config and reload the game if changed";
+				   "must save config and reload the game if changed"
+#endif
+				   ;
+static const char h_plugin_spu[] = ""
+#ifndef NO_DYLIB
+				   "spunull effectively disables sound\n"
+				   "must save config and reload the game if changed"
+#endif
+;
 // static const char h_gpu_peops[]  = "Configure P.E.Op.S. SoftGL Driver V1.17";
 // static const char h_gpu_peopsgl[]= "Configure P.E.Op.S. MesaGL Driver V1.78";
 // static const char h_gpu_unai[]   = "Configure Unai/PCSX4ALL Team plugin (new)";

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1528,9 +1528,18 @@ static const char h_plugin_gpu[] =
 #elif defined(BUILTIN_GPU_UNAI)
 				   "builtin_gpu is the Unai GPU, very fast\n"
 #endif
+#if !defined(BUILTIN_GPU_NEON) && defined(GPU_NEON)
+				   "gpu_neon is Exophase's NEON GPU, fast and accurate\n"
+#endif
+#ifndef BUILTIN_GPU_PEOPS
 				   "gpu_peops is Pete's soft GPU, slow but accurate\n"
+#endif
+#ifndef BUILTIN_GPU_UNAI
 				   "gpu_unai is the GPU renderer from PCSX4ALL\n"
+#endif
+#ifdef HAVE_GLES
 				   "gpu_gles Pete's hw GPU, uses 3D chip but is glitchy\n"
+#endif
 				   "must save config and reload the game if changed";
 static const char h_plugin_spu[] = "spunull effectively disables sound\n"
 				   "must save config and reload the game if changed";


### PR DESCRIPTION
For that reusing existing C macros (to much of them), and adding new configure variable HAVE_NEON_GPU. The peops & unai are build/supported either way.
Will try to close plugin stuff with this one.