### PR TITLE
frontend: disable dl func. support on static builds

### DIFF
--- a/configure
+++ b/configure
@@ -610,7 +610,11 @@ if [ "$ARCH" = "arm" ]; then
   echo "ARMv7 optimizations $have_armv7"
   echo "TI C64x DSP support $have_c64x_dsp"
 fi
-echo "tslib support       $have_tslib"
+if [ "$have_dynamic" = "yes" ]; then
+  echo "tslib support       $have_tslib"
+else
+  echo "tslib does NOT support staticly linked build"
+fi
 if [ "$platform" = "generic" ]; then
   echo "OpenGL ES output    $have_gles"
 fi
@@ -643,7 +647,7 @@ fi
 if [ "$have_arm_neon_asm" = "yes" ]; then
   echo "HAVE_NEON_ASM = 1" >> $config_mak
 fi
-if [ "$have_tslib" = "yes" ]; then
+if [ "$have_tslib" = "yes" -a "$have_dynamic" = "yes" ]; then
   echo "HAVE_TSLIB = 1" >> $config_mak
 fi
 if [ "$have_evdev" = "yes" ]; then

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -12,7 +12,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#ifndef NO_DYLIB
 #include <dlfcn.h>
+#endif
 #include <zlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -2472,7 +2474,6 @@ static void scan_bios_plugins(void)
 	char fname[MAXPATHLEN];
 	struct dirent *ent;
 	int bios_i, gpu_i, spu_i, mc_i;
-	char *p;
 	DIR *dir;
 
 	bioses[0] = "HLE";
@@ -2485,7 +2486,11 @@ static void scan_bios_plugins(void)
 	dir = opendir(fname);
 	if (dir == NULL) {
 		perror("scan_bios_plugins bios opendir");
+#ifndef NO_DYLIB
 		goto do_plugins;
+#else
+		goto do_memcards;
+#endif
 	}
 
 	while (1) {
@@ -2519,7 +2524,9 @@ static void scan_bios_plugins(void)
 
 	closedir(dir);
 
+#ifndef NO_DYLIB
 do_plugins:
+	char *p;
 	snprintf(fname, sizeof(fname), "%s/", Config.PluginsDir);
 	dir = opendir(fname);
 	if (dir == NULL) {
@@ -2570,6 +2577,7 @@ do_plugins:
 	}
 
 	closedir(dir);
+#endif
 
 do_memcards:
 	dir = opendir("." MEMCARD_DIR);


### PR DESCRIPTION
Personally I've not seen staticly linked build loading dynamicly shared objects, also some libc even don't have dlfcn.h implemented in them (not to say anything about Windows although there are [workarounds](https://github.com/dlfcn-win32/dlfcn-win32)).

`tslib` depends on dlfcn so we have to disable it when `have_dynamic=no` (added small warning in configure echo)

This fixes build on our static uClibc toolchain with `configure --disable-dynamic`, but it should go after https://github.com/notaz/pcsx_rearmed/pull/367 (sorry for being ahead of myself).