### PR TITLE
frontend/menu: label can only go with statement

### DIFF
--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2542,7 +2542,6 @@ static void scan_bios_plugins(void)
 
 #ifndef NO_DYLIB
 do_plugins:
-	char *p;
 	snprintf(fname, sizeof(fname), "%s/", Config.PluginsDir);
 	dir = opendir(fname);
 	if (dir == NULL) {
@@ -2552,6 +2551,7 @@ do_plugins:
 
 	while (1) {
 		void *h, *tmp;
+		char *p;
 
 		errno = 0;
 		ent = readdir(dir);


### PR DESCRIPTION
`error: a label can only be part of a statement and a declaration is not a statement`

I've unintenionally broke shared build on older gcc (e.g 9.4.0), so we either add an empty statement after label or move declaration down (_mea culpa_).