### PR TITLE
frontend/libretro: default to 50% underclock for pre_ARMv7

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2375,7 +2375,11 @@ static void update_variables(bool in_flight)
    {
       int psxclock = atoi(var.value);
       if (strcmp(var.value, "auto") == 0 || psxclock == 0)
+#if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
+         Config.cycle_multiplier = 200;
+#else
          Config.cycle_multiplier = CYCLE_MULT_DEFAULT;
+#endif
       else
          Config.cycle_multiplier = 10000 / psxclock;
    }


### PR DESCRIPTION
goes inline with libretro_core_options