### PR TITLE
frontend/menu: add "Downscale Hi-Res" option

### DIFF
--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -1452,6 +1452,7 @@ static menu_entry e_menu_plugin_gpu_unai[] =
 	mee_onoff     ("Lighting",                   0, pl_rearmed_cbs.gpu_unai.lighting, 1),
 	mee_onoff     ("Fast lighting",              0, pl_rearmed_cbs.gpu_unai.fast_lighting, 1),
 	mee_onoff     ("Blending",                   0, pl_rearmed_cbs.gpu_unai.blending, 1),
+	mee_onoff     ("Downscale Hi-Res",           0, pl_rearmed_cbs.gpu_unai.scale_hires, 1),
 	mee_end,
 };
 


### PR DESCRIPTION
mandatory for 320x240 disp, also present in libretro port.

I've notice also `pixel_skip` opt. but didn't notice any performance gain so not sure about it's usability and not adding as such.