### PR TITLE
frontend: for cust cfg && `-cdfile` use run_cd_image

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -658,10 +658,10 @@ int main(int argc, char *argv[])
 	in_init();
 	pl_init();
 	plat_init();
+	menu_init(); // loads config
+
 	if (emu_core_init() != 0)
 		return 1;
-	CheckCdrom();
-	menu_init(cdfile ? 1 : 0); // loads config
 
 	if (psxout)
 		Config.PsxOut = 1;
@@ -682,6 +682,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	CheckCdrom();
 	plugin_call_rearmed_cbs();
 	SysReset();
 

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -658,10 +658,10 @@ int main(int argc, char *argv[])
 	in_init();
 	pl_init();
 	plat_init();
-	menu_init(); // loads config
-
 	if (emu_core_init() != 0)
 		return 1;
+	CheckCdrom();
+	menu_init(cdfile ? 1 : 0); // loads config
 
 	if (psxout)
 		Config.PsxOut = 1;
@@ -682,7 +682,6 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	CheckCdrom();
 	plugin_call_rearmed_cbs();
 	SysReset();
 

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -711,6 +711,8 @@ int main(int argc, char *argv[])
 	if (ready_to_go) {
 		if (menu_load_config(1) != 0)
 			menu_load_config(0);
+		else if (cdfile)
+			run_cd_image(cdfile); // reload cfg's custom plugins
 		menu_prepare_emu();
 
 		// If a state has been specified, then load that

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2651,7 +2651,7 @@ do_memcards:
 	closedir(dir);
 }
 
-void menu_init(int cdarg)
+void menu_init(void)
 {
 	char buff[MAXPATHLEN];
 	int i;
@@ -2662,8 +2662,7 @@ void menu_init(int cdarg)
 	menu_init_base();
 
 	menu_set_defconfig();
-	if (cdarg && menu_load_config(1) != 0)
-		menu_load_config(0);
+	menu_load_config(0);
 	menu_do_last_cd_img(1);
 	last_vout_w = 320;
 	last_vout_h = 240;

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2166,7 +2166,7 @@ static int run_exe(void)
 	return 0;
 }
 
-static int run_cd_image(const char *fname)
+int run_cd_image(const char *fname)
 {
 	int autoload_state = g_autostateld_opt;
 	size_t fname_len = strlen(fname);

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -2651,7 +2651,7 @@ do_memcards:
 	closedir(dir);
 }
 
-void menu_init(void)
+void menu_init(int cdarg)
 {
 	char buff[MAXPATHLEN];
 	int i;
@@ -2662,7 +2662,8 @@ void menu_init(void)
 	menu_init_base();
 
 	menu_set_defconfig();
-	menu_load_config(0);
+	if (cdarg && menu_load_config(1) != 0)
+		menu_load_config(0);
 	menu_do_last_cd_img(1);
 	last_vout_w = 320;
 	last_vout_h = 240;

--- a/frontend/menu.h
+++ b/frontend/menu.h
@@ -8,6 +8,7 @@ void menu_finish(void);
 
 void menu_notify_mode_change(int w, int h, int bpp);
 int  menu_load_config(int is_game);
+int  run_cd_image(const char *fname);
 
 enum g_opts_opts {
 	OPT_SHOWFPS = 1 << 0,

--- a/frontend/menu.h
+++ b/frontend/menu.h
@@ -1,7 +1,7 @@
 #ifndef __MENU_H__
 #define __MENU_H__
 
-void menu_init(void);
+void menu_init(int cdarg);
 void menu_prepare_emu(void);
 void menu_loop(void);
 void menu_finish(void);

--- a/frontend/menu.h
+++ b/frontend/menu.h
@@ -1,7 +1,7 @@
 #ifndef __MENU_H__
 #define __MENU_H__
 
-void menu_init(int cdarg);
+void menu_init(void);
 void menu_prepare_emu(void);
 void menu_loop(void);
 void menu_finish(void);


### PR DESCRIPTION
fixes loading ROM with specific plugins from custom <CdLabel>-<CdID>.cfg

Otherwise we end up emu launching with plugins from default config, while menu states we are on another plugins (from custom config). I tried to load game config before loading plugins (see https://github.com/notaz/pcsx_rearmed/commit/add930ed21810a1819932c522ddc0754e988f573), but couldn't get menu_load_config() to pass correct cfg name.