### PR TITLE
Update libretro_core_options.h: Improved pcsx_rearmed_show_bios_bootlogo

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -137,9 +137,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_show_bios_bootlogo",
-      "Show BIOS Boot Logo",
+      "Show BIOS Name/Boot Logo",
       NULL,
-      "When using an official BIOS file, specify whether to show the PlayStation logo upon starting or resetting content. Also enables the display of BIOS file name in OSD. Warning: Enabling the boot logo may reduce game compatibility.",
+      "When using an official BIOS file, enables the display of the BIOS file name in the OSD. Also specifies whether to show the PlayStation logo when starting or selecting Reset. Warning: Enabling the boot logo may reduce game compatibility.",
       NULL,
       "system",
       {

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -139,7 +139,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "pcsx_rearmed_show_bios_bootlogo",
       "Show BIOS Name/Boot Logo",
       NULL,
-      "When using an official BIOS file, enables the display of the BIOS file name in the OSD. Also specifies whether to show the PlayStation logo when starting or selecting Reset. Warning: Enabling the boot logo may reduce game compatibility.",
+      "When using a custom BIOS file, enables the display of its file name in the OSD. Also specifies whether to show the BIOS logo when starting or selecting Reset. Warning: Enabling the logo may reduce game compatibility.",
       NULL,
       "system",
       {


### PR DESCRIPTION
* Replaced "Show BIOS Boot Logo" with "Show BIOS Name/Boot Logo"
* Stated name before bios logo because that is the chronologcal order how they display.
* Replaced "resetting" with "Reset"
  - In RetroArch, "Restart" has been replaced with "Reset" so now it's safe to use that term: https://github.com/libretro/RetroArch/issues/18775, https://github.com/libretro/RetroArch/commit/d2457585b1dddc884ef85559ed52f247da02e89c