### PR TITLE
gte: Fix native divide

### DIFF
--- a/libpcsxcore/disr3000a.c
+++ b/libpcsxcore/disr3000a.c
@@ -21,6 +21,8 @@
 * R3000A disassembler.
 */
 
+#include <stdio.h>
+
 #include "psxcommon.h"
 
 // XXX: don't care but maybe fix it someday

--- a/libpcsxcore/gte.c
+++ b/libpcsxcore/gte.c
@@ -386,8 +386,8 @@ static inline u32 getFinalFlag(u32 flags) {
 
 //senquack - n param should be unsigned (will be 'gteH' reg which is u16)
 #ifdef GTE_USE_NATIVE_DIVIDE
-INLINE u32 DIVIDE(u16 n, u16 d) {
-	return ((u32)n << 16) / d;
+static inline u32 DIVIDE(u16 n, u16 d) {
+	return (((u32)n << 16) + (d >> 1)) / d;
 }
 #else
 #include "gte_divider.h"


### PR DESCRIPTION
The algorithm was wrong if you look at the Nocash docs. It also caused very visible seams between polygons, which are greatly reduced now.